### PR TITLE
Add page numbers to pagination and corresponding tests

### DIFF
--- a/src/components/search/pagination/src/Pagination.tsx
+++ b/src/components/search/pagination/src/Pagination.tsx
@@ -33,6 +33,7 @@ export function generatePages(currentPage, totalPages, options) {
   pages.push({ type: "number", page: currentPage, active: true })
   if (currentPage < totalPages) {
     const max = Math.min(currentPage + pageScope, totalPages)
+    for (let i = currentPage + 1; i <= max; i++) pages.push({ type: "number", page: i })
   }
   if (currentPage < totalPages - pageScope) pages.push({ type: "ellipsis" })
 

--- a/src/components/search/pagination/src/Pagination.tsx
+++ b/src/components/search/pagination/src/Pagination.tsx
@@ -2,105 +2,211 @@ import * as React from "react";
 import "../styles/index.scss";
 
 import {
-	SearchkitComponent,
-	PaginationAccessor,
-	FastClick,
-	SearchkitComponentProps
+  SearchkitComponent,
+  PaginationAccessor,
+  FastClick,
+  SearchkitComponentProps
 } from "../../../../core"
 
 const defaults = require("lodash/defaults")
 const get = require("lodash/get")
 const assign = require("lodash/assign")
+const map = require("lodash/map")
 
-export interface PaginationProps extends SearchkitComponentProps {
+
+// export enum DIRECTION {
+//  NEXT,
+//  PREVIOUS
+// }
+
+export interface PaginationDisplayProps {
+  currentPage: number
+  totalPages: number
+  showNumbers?: boolean
+  pageScope?: number // Number of page to show before/after the current number
+  bemBlocks: any
+  urlBuilder: (number) => string
+  translate: (string) => string
+  setPage: (number) => void
 }
 
-export enum DIRECTION {
-	NEXT,
-	PREVIOUS
+export interface PaginationDisplayState { }
+
+export class PaginationDisplay extends React.Component<PaginationDisplayProps, PaginationDisplayState> {
+
+  static propTypes = {
+    currentPage: React.PropTypes.number.isRequired,
+    totalPages: React.PropTypes.number.isRequired,
+    urlBuilder: React.PropTypes.func.isRequired,
+    showNumbers: React.PropTypes.bool,
+    pageScope: React.PropTypes.number,
+    setPage: React.PropTypes.func,
+  }
+
+  static defaultProps = {
+    showNumbers: true,
+    pageScope: 3
+  }
+
+  isDisabled(pageNumber: number): boolean {
+    return (pageNumber < 1) || (pageNumber > this.props.totalPages);
+  }
+
+  render() {
+    const { showNumbers, currentPage, pageScope, bemBlocks, totalPages } = this.props;
+    // Renders numbers for pages, like "1, ..., 3, 4, 5, 6, 7, ..."
+    return (
+      <div className={bemBlocks.container() } data-qa="pagination">
+        {this.renderPaginationElement(currentPage - 1, "prev", "pagination.previous") }
+        {currentPage > pageScope + 1 ? this.renderPaginationElement(1, "number") : undefined}
+        {currentPage > pageScope + 2 ? this.renderEllipsis() : undefined}
+        {this.renderPageNumbers(currentPage - pageScope, currentPage - 1) }
+        {this.renderPaginationElement(currentPage, "number", "" + currentPage) }
+        {this.renderPageNumbers(currentPage + 1, currentPage + pageScope) }
+        {currentPage < totalPages - pageScope ? this.renderEllipsis() : undefined}
+        {this.renderPaginationElement(currentPage + 1, "next", "pagination.next") }
+      </div>
+    )
+  }
+
+  renderPageNumbers(min: number, max: number) {
+    const { showNumbers, totalPages } = this.props;
+    if (!showNumbers) return undefined;
+
+    const minPage = Math.max(1, min);
+    const maxPage = Math.min(totalPages, max);
+    let arr = [];
+    for (var i = minPage; i <= maxPage; i++) {
+      arr.push(this.renderPaginationElement(i, "number"));
+    }
+    return arr;
+  }
+
+  renderEllipsis(){
+    const { showNumbers, bemBlocks } = this.props;
+    if (!showNumbers) return undefined;
+
+    const className = bemBlocks.option()
+      .mix(bemBlocks.container("item"))
+      .mix(bemBlocks.option("number"))
+      .state({
+        disabled: true
+      })
+    return (
+      <div className={className}>
+        <div className={bemBlocks.option("text") }>...</div>
+        </div>
+    )
+  }
+
+  renderPaginationElement(pageNumber: number, cssClass: string, text?: string) {
+    const { showNumbers, currentPage, bemBlocks, translate, setPage, urlBuilder } = this.props;
+
+    // Block numbers ?
+    if (!showNumbers && (cssClass == "number")) return undefined
+
+    const disabled = this.isDisabled(pageNumber);
+    const className = bemBlocks.option()
+      .mix(bemBlocks.container("item"))
+      .mix(bemBlocks.option(cssClass))
+      .state({
+        active: (pageNumber === currentPage),
+        disabled
+      })
+
+          //  data-q={displayText}
+    // previous/next or page number ?
+    const displayText = text ? translate(text) : ("" + pageNumber);
+    if (disabled){
+      return (
+        <div className={className}>
+          <div className={bemBlocks.option("text") }>{displayText}</div>
+        </div>
+      )
+    } else {
+      return (
+        <FastClick key={displayText} handler={() => setPage(pageNumber) }>
+          <a className={className} href={urlBuilder(pageNumber) }>
+            <div className={bemBlocks.option("text") }>{displayText}</div>
+          </a>
+        </FastClick>
+      )
+    }
+  }
+}
+
+
+export interface PaginationProps extends SearchkitComponentProps {
+  showNumbers?: boolean
+  pageScope?: number // Number of page to show before/after the current number
 }
 
 export class Pagination extends SearchkitComponent<PaginationProps, any> {
-	accessor:PaginationAccessor
+  accessor:PaginationAccessor
 
 
-	static translations:any = {
-		"pagination.previous":"Previous",
-		"pagination.next":"Next"
-	}
-	translations = Pagination.translations
+  static translations:any = {
+    "pagination.previous":"Previous",
+    "pagination.next":"Next"
+  }
+  translations = Pagination.translations
 
-	static propTypes = defaults({
-		translations:SearchkitComponent.translationsPropType(
-			Pagination.translations
-		)
-	}, SearchkitComponent.propTypes)
+  static propTypes = defaults({
+    translations:SearchkitComponent.translationsPropType(
+      Pagination.translations
+    ),
+    showNumbers:React.PropTypes.bool
+  }, SearchkitComponent.propTypes)
 
-	defineAccessor() {
+  defineAccessor() {
     return new PaginationAccessor("p")
-	}
+  }
 
-	defineBEMBlocks() {
-		let block = (this.props.mod || "pagination-navigation")
-		return {
-			container: block,
-			option: `${block}-item`
-		}
-	}
+  defineBEMBlocks() {
+    let block = (this.props.mod || "pagination-navigation")
+    return {
+      container: block,
+      option: `${block}-item`
+    }
+  }
 
-	getCurrentPage():number {
-		return Number(this.accessor.state.getValue()) || 1;
-	}
+  getCurrentPage():number {
+    return Number(this.accessor.state.getValue()) || 1;
+  }
 
-	setPage(direction:DIRECTION) {
-		if (this.isDisabled(direction)) { return };
-		let currentPage:number = this.getCurrentPage();
-		if (direction == DIRECTION.PREVIOUS) {
-			this.accessor.state = this.accessor.state.setValue(currentPage-1);
-		} else if (direction == DIRECTION.NEXT) {
-			this.accessor.state = this.accessor.state.setValue(currentPage+1);
-		}
-		this.searchkit.performSearch();
-		window.scrollTo(0,0);
-	}
+  getTotalPages():number {
+    return Math.ceil(
+      get(this.getResults(), ".hits.total", 1)
+      /
+      get(this.getQuery(), "query.size", 10)
+    );
+  }
 
-	isDisabled(direction:DIRECTION):boolean {
-		let currentPage:number = this.getCurrentPage();
-		let totalPages:number = Math.ceil(
-			get(this.getResults(),".hits.total",1)
-			/
-			get(this.getQuery(), "query.size", 10)
-		)
-		if (direction == DIRECTION.PREVIOUS && currentPage == 1) { return true; }
-		if (direction == DIRECTION.NEXT && currentPage == totalPages ) { return true; }
-		return false;
-	}
+  isDisabled(pageNumber: number): boolean {
+    return (pageNumber < 1) || (pageNumber >= this.getTotalPages());
+  }
 
-	paginationElement(direction:DIRECTION, cssClass:string, displayText:string ) {
-		let className = this.bemBlocks.option()
-			.mix(this.bemBlocks.container("item"))
-			.mix(this.bemBlocks.option(cssClass))
-			.state({
-				disabled:this.isDisabled(direction)
-			})
-    return (
-			<FastClick handler={this.setPage.bind(this,direction)}>
-	      <div className={className} data-qa={direction}>
-	        <div className={this.bemBlocks.option("text")}>{this.translate(displayText)}</div>
-	      </div>
-			</FastClick>
-		)
-	}
+  setPage(pageNumber:number) {
+    if (this.isDisabled(pageNumber)) { return };
+    if (pageNumber == this.getCurrentPage()) {
+      return; // Same page, no need to rerun query
+    }
+    this.accessor.state = this.accessor.state.setValue(pageNumber);
+    this.searchkit.performSearch();
+    window.scrollTo(0,0); // BUG, doesn't work for inner divs
+  }
 
   render() {
-		if(this.hasHits()){
-			return (
-				<div className={this.bemBlocks.container()} data-qa="pagination">
-					{this.paginationElement(DIRECTION.PREVIOUS, "prev", "pagination.previous")}
-					{this.paginationElement(DIRECTION.NEXT, "next", "pagination.next")}
-      	</div>
-			)
-		}
-		return null
+    if (!this.hasHits()) return null;
+
+    const { showNumbers, pageScope } = this.props;
+    return <PaginationDisplay currentPage={this.getCurrentPage()}
+                              totalPages={this.getTotalPages()}
+                              showNumbers={showNumbers}
+                              pageScope={pageScope}
+                              bemBlocks={this.bemBlocks}
+                              translate={this.translate.bind(this)}
+                              urlBuilder={this.accessor.urlWithState}
+                              setPage={this.setPage.bind(this)} />
   }
 }

--- a/src/components/search/pagination/styles/index.scss
+++ b/src/components/search/pagination/styles/index.scss
@@ -1,33 +1,51 @@
 .pagination-navigation {
-  display:flex;
-  justify-content: space-between;
-  margin:0 auto;
-  max-width:300px;
+  /*display:flex;*/
+  /*justify-content: space-between;*/
+  margin:0 auto 16px auto;
+  /*max-width:300px;*/
+  text-align: center;
 
-  &__next {
+/*  &__next {
     align-self: flex-end;
   }
   &__previous {
     align-self: flex-start;
   }
-
+*/
 }
 
 .pagination-navigation-item {
   border:1px solid #08c;
   border-radius:20px;
-  flex:1 1 200px;
-  max-width:140px;
+  /*flex:1 1 200px;*/
+  /*max-width:140px;*/
+  display: inline-block;
   padding:10px 20px;
   text-align:center;
   cursor:pointer;
+  text-decoration: none;
+
   &__text {
     font-size:14px;
     color:#08c;
   }
 
+  &__number &__text {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+
   &.is-disabled {
     border-color: #ddd;
+    cursor: initial;
+  }
+
+  &.is-active {
+    background: #08c;
+  }
+
+  &.is-active &__text{
+    color: #fff;
   }
 
   &.is-disabled &__text {

--- a/src/components/search/pagination/test/PaginationSpec.tsx
+++ b/src/components/search/pagination/test/PaginationSpec.tsx
@@ -13,9 +13,12 @@ describe("Pagination tests", () => {
 
     this.searchkit = SearchkitManager.mock()
 
-    this.createWrapper = () => {
+    this.createWrapper = (showNumbers=true, pageScope=3) => {
       this.wrapper = mount(
-        <Pagination searchkit={this.searchkit} translations={{"pagination.previous":"Previous Page"}} />
+        <Pagination searchkit={this.searchkit}
+                    showNumbers={showNumbers}
+                    pageScope={pageScope}
+                    translations={{ "pagination.previous": "Previous Page" }} />
       );
       this.accessor = this.searchkit.accessors.getAccessors()[0]
     }
@@ -25,7 +28,7 @@ describe("Pagination tests", () => {
 
     this.searchkit.setResults({
       hits:{
-        total:40
+        total:80
       }
     })
 
@@ -36,14 +39,15 @@ describe("Pagination tests", () => {
 
     beforeEach(() => {
 
-      this.checkActionStates = (page, prevDisabled, nextDisabled) => {
-        this.createWrapper()
+      this.checkActionStates = (page, prevDisabled, nextDisabled, pages) => {
         this.accessor.state = this.accessor.state.setValue(page)
         this.wrapper.update()
         expect(this.wrapper.find(".pagination-navigation-item__prev")
           .hasClass("is-disabled")).toBe(prevDisabled)
         expect(this.wrapper.find(".pagination-navigation-item__next")
           .hasClass("is-disabled")).toBe(nextDisabled)
+        const pageNumbers = this.wrapper.find(".pagination-navigation-item__number").map(e => e.text());
+        expect(pageNumbers).toEqual(pages);
       }
 
     })
@@ -55,16 +59,29 @@ describe("Pagination tests", () => {
     })
 
     it('renders first page options', () => {
-      this.checkActionStates(null,true, false)
-    });
+      this.createWrapper()
+      this.checkActionStates(null,true, false, ['1', '2', '3', '4', '...'])
+    })
 
     it('renders second page options', () => {
-      this.checkActionStates(2, false, false)
-    });
+      this.createWrapper()
+      this.checkActionStates(2, false, false, ['1', '2', '3', '4', '5', '...'])
+    })
 
-    it('renders forth page options', () => {
-      this.checkActionStates(4, false, true)
-    });
+    it('renders eighth page options', () => {
+      this.createWrapper()
+      this.checkActionStates(8, false, true, ['1', '...', '5', '6', '7', '8'])
+    })
+
+    it("handles showNumbers prop", () => {
+      this.createWrapper(false)
+      this.checkActionStates(4, false, false, [])
+    })
+
+    it("handles pageScope prop", () => {
+      this.createWrapper(true, 1)
+      this.checkActionStates(4, false, false, ['1', '...', '3', '4', '5', '...'])
+    })
 
     it("renders no pagination on no results", () => {
       this.searchkit.setResults({hits:{total:0}})
@@ -73,10 +90,10 @@ describe("Pagination tests", () => {
     })
 
     it("both disabled on only one total page", () => {
-      this.searchkit.setResults({hits:{total:10}})
+      this.searchkit.setResults({ hits: { total: 10 } })
       this.createWrapper()
       expect(this.wrapper.find(".pagination-navigation").length).toBe(1)
-      this.checkActionStates(1, true, true)
+      this.checkActionStates(1, true, true, ['1'])
     })
 
   });
@@ -93,13 +110,13 @@ describe("Pagination tests", () => {
 
     it("click previous, next", ()=> {
       this.createWrapper()
-      this.accessor.state = this.accessor.state.setValue(5)
+      this.accessor.state = this.accessor.state.setValue(3)
       this.wrapper.update()
       fastClick(this.wrapper.find( ".pagination-navigation-item__prev" ))
+      expect(this.accessor.state.getValue()).toBe(2)
+      fastClick(this.wrapper.find( ".pagination-navigation-item__next" ))
+      fastClick(this.wrapper.find( ".pagination-navigation-item__next" ))
       expect(this.accessor.state.getValue()).toBe(4)
-      fastClick(this.wrapper.find( ".pagination-navigation-item__next" ))
-      fastClick(this.wrapper.find( ".pagination-navigation-item__next" ))
-      expect(this.accessor.state.getValue()).toBe(6)
 
     })
 

--- a/src/components/search/pagination/test/PaginationSpec.tsx
+++ b/src/components/search/pagination/test/PaginationSpec.tsx
@@ -46,10 +46,16 @@ describe("Pagination tests", () => {
           .hasClass("is-disabled")).toBe(prevDisabled)
         expect(this.wrapper.find(".pagination-navigation-item__next")
           .hasClass("is-disabled")).toBe(nextDisabled)
-        const pageNumbers = this.wrapper.find(".pagination-navigation-item__number").map(e => e.text());
-        expect(pageNumbers).toEqual(pages);
-      }
+        const pageNumbers = this.wrapper.find(".pagination-navigation-item__number");
+        expect(pageNumbers.map(e => e.text())).toEqual(pages);
 
+        // Check links
+        pageNumbers.forEach((e, idx) => {
+          if (e.text() !== '...'){
+            expect(e.html()).toContain('"/context.html?p=' + pages[idx] + '"')
+          }
+        })
+      }
     })
 
     it("renders text", () => {

--- a/src/core/SearchkitManager.ts
+++ b/src/core/SearchkitManager.ts
@@ -6,10 +6,12 @@ import {ESTransport, AxiosESTransport, MockESTransport} from "./transport";
 import {SearchRequest} from "./SearchRequest"
 import {Utils, EventEmitter} from "./support"
 import {VERSION} from "./SearchkitVersion"
+
 const defaults = require("lodash/defaults")
 const constant = require("lodash/constant")
 const isEqual = require("lodash/isEqual")
 const get = require("lodash/get")
+const qs = require("qs")
 
 require('es6-promise').polyfill()
 
@@ -132,6 +134,12 @@ export class SearchkitManager {
         this.history.replaceState : this.history.pushState
       historyMethod(null, window.location.pathname, this.state)
     }
+  }
+
+  buildSearchUrl(extraParams = {}){
+    const params = defaults(extraParams, this.accessors.getState())
+    const queryString = qs.stringify(params, { encode: true })
+    return window.location.pathname + '?' + queryString
   }
 
   search(replaceState=false){

--- a/src/core/SearchkitManager.ts
+++ b/src/core/SearchkitManager.ts
@@ -137,7 +137,7 @@ export class SearchkitManager {
   }
 
   buildSearchUrl(extraParams = {}){
-    const params = defaults(extraParams, this.accessors.getState())
+    const params = defaults(extraParams, this.state || this.accessors.getState())
     const queryString = qs.stringify(params, { encode: true })
     return window.location.pathname + '?' + queryString
   }

--- a/src/core/accessors/StatefulAccessor.ts
+++ b/src/core/accessors/StatefulAccessor.ts
@@ -12,6 +12,7 @@ export class StatefulAccessor<T extends State<any>> extends Accessor {
     super()
     this.key = key
     this.urlKey = urlString || key && key.replace(/\./g, "_")
+    this.urlWithState = this.urlWithState.bind(this)
   }
 
   onStateChange(oldState){
@@ -46,6 +47,10 @@ export class StatefulAccessor<T extends State<any>> extends Accessor {
 
   resetState(){
     this.state = this.state.clear()
+  }
+
+  urlWithState(state:T) {
+    return this.searchkit.buildSearchUrl({ [this.urlKey]: state })
   }
 
 }


### PR DESCRIPTION
Pagination : add page numbers
Fixes #40 
New props : showNumbers and pageScope (number of page numbers to show before and after the current one)

![image](https://cloud.githubusercontent.com/assets/1522455/12706267/28596a6a-c881-11e5-89f8-cea6121fc382.png)


WIP version, adds page numbers.
Props: showNumbers and pageScope
Missing disabled ‘…’ when there are too many pages (previous, 1, …, 5,
6, 7, 8, 9, …, 147, next)

Use links for pagination buttons

Added SearchkitManager.buildSearchUrl(extraParams) to create new urls
with different parameters
Pagination buttons are now links

Move url building to accessor

Pagination : show ellipsis on page ranges

Add Pagination tests and fix showNumbers prop