### PR TITLE
WIP prevProps.hitsPerPage update - don't merge !

### DIFF
--- a/src/components/search/hits/src/Hits.tsx
+++ b/src/components/search/hits/src/Hits.tsx
@@ -42,6 +42,7 @@ export interface HitsProps extends SearchkitComponentProps{
 
 
 export class Hits extends SearchkitComponent<HitsProps, any> {
+  accessor: PageSizeAccessor
 
 	static propTypes = defaults({
 		hitsPerPage:React.PropTypes.number.isRequired,
@@ -74,11 +75,16 @@ export class Hits extends SearchkitComponent<HitsProps, any> {
 		}
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate(prevProps) {
 		if(!!this.props.scrollTo && !this.isLoading() && this.hasHitsChanged()) {
 			const scrollSelector:string = (this.props.scrollTo == true) ? "body" : this.props.scrollTo.toString()
 			document.querySelector(scrollSelector).scrollTop = 0;
 		}
+    // Check for hitsPerPage change
+    if (prevProps.hitsPerPage != this.props.hitsPerPage){
+      this.accessor.size = this.props.hitsPerPage
+      this.searchkit.performSearch()
+    }
 	}
 
 	defineAccessor(){


### PR DESCRIPTION
Works in the playground to update the page number using a select. Doesn't reset the page number. 

What's the expected behavior regarding the page number ? Should we convert the current page to the new page number, taking into account the number of hits per page, or just reset to page 1 ?