### PR TITLE
SearchkitComponent's contextTypes should be a React.ValidationMap<any>

### DIFF
--- a/src/core/react/SearchkitComponent.ts
+++ b/src/core/react/SearchkitComponent.ts
@@ -21,7 +21,7 @@ export class SearchkitComponent<P extends SearchkitComponentProps,S> extends Rea
   stateListenerUnsubscribe:Function
   translations:Object = {}
 
-  static contextTypes = {
+  static contextTypes: React.ValidationMap<any> = {
 		searchkit:React.PropTypes.instanceOf(SearchkitManager)
 	}
 


### PR DESCRIPTION
Fixes #164