### PR TITLE
[WIP] multi-searchbox (will be converted to InputFilter)

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./search/filters/checkbox-filter/CheckboxFilter";
+export * from "./search/filters/input-filter/InputFilter";
 export * from "./search/filters/reset-filters/src/ResetFilters";
 export * from "./search/filters/selected-filters/src/GroupedSelectedFilters";
 export * from "./search/filters/selected-filters/src/SelectedFilters";

--- a/src/components/search/filters/input-filter/InputFilter.tsx
+++ b/src/components/search/filters/input-filter/InputFilter.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+
+import {
+  SearchkitComponent,
+  SearchkitComponentProps,
+  ReactComponentType
+} from "../../../../core";
+
+import { SearchBox } from "../../search-box/src/SearchBox"
+
+import {
+  Panel
+} from "../../../ui"
+
+const defaults = require('lodash/defaults')
+
+export interface InputFilterProps extends SearchkitComponentProps {
+  id: string
+  title: string
+  mod?: string
+  searchOnChange?:boolean
+  searchThrottleTime?:number
+  queryFields?:Array<string>
+  prefixQueryFields?:Array<string>
+  queryOptions?:any
+  placeholder?: string
+  containerComponent?: ReactComponentType<any>
+  collapsable?: boolean
+}
+
+export class InputFilter extends SearchkitComponent<InputFilterProps, any> {
+
+  static propTypes = defaults({
+    id: React.PropTypes.string.isRequired,
+    title: React.PropTypes.string.isRequired,
+    searchOnChange: React.PropTypes.bool,
+    searchThrottleTime: React.PropTypes.number,
+    queryFields:React.PropTypes.arrayOf(React.PropTypes.string),
+    prefixQueryFields:React.PropTypes.arrayOf(React.PropTypes.string),
+    queryOptions:React.PropTypes.object,
+    collapsable: React.PropTypes.bool,
+    mod: React.PropTypes.string,
+    placeholder: React.PropTypes.string
+  }, SearchkitComponent.propTypes)
+
+  static defaultProps = {
+    containerComponent: Panel,
+    collapsable: false,
+    mod: "sk-input-filter"
+  }
+
+  render() {
+    const { containerComponent, title, id, collapsable } = this.props
+
+
+    return React.createElement(containerComponent, {
+      title,
+      className: id ? `filter--${id}` : undefined,
+      disabled: false,
+      collapsable
+    },
+      <SearchBox id={id} 
+        mod={this.props.mod}
+        queryFields={this.props.queryFields}
+        prefixQueryFields={this.props.prefixQueryFields}
+        queryOptions={this.props.queryOptions}
+        searchOnChange={this.props.searchOnChange}
+        searchThrottleTime={this.props.searchThrottleTime}
+        placeholder={this.props.placeholder}
+        autofocus={false} />
+    );
+  }
+
+}

--- a/src/components/search/search-box/src/SearchBox.tsx
+++ b/src/components/search/search-box/src/SearchBox.tsx
@@ -17,6 +17,8 @@ export interface SearchBoxProps extends SearchkitComponentProps {
   autofocus?:boolean
   queryOptions?:any
   id?: string
+  mod?: string
+  placeholder?: string
   prefixQueryFields?:Array<string>
 }
 
@@ -32,6 +34,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
 
   static defaultProps = {
     id: 'q',
+    mod: 'sk-search-box',
     searchThrottleTime:200
   }
 
@@ -45,7 +48,9 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
     prefixQueryFields:React.PropTypes.arrayOf(React.PropTypes.string),
     translations:SearchkitComponent.translationsPropType(
       SearchBox.translations
-    )
+    ),
+    mod: React.PropTypes.string,
+    placeholder: React.PropTypes.string
   }, SearchkitComponent.propTypes)
 
   constructor (props:SearchBoxProps) {
@@ -64,7 +69,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
   }
 
   defineBEMBlocks() {
-    return {container:(this.props.mod || "sk-search-box")};
+    return { container:this.props.mod };
   }
 
   defineAccessor(){
@@ -118,7 +123,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
           <input type="text"
           data-qa="query"
           className={block("text")}
-          placeholder={this.translate("searchbox.placeholder")}
+          placeholder={this.props.placeholder || this.translate("searchbox.placeholder")}
           value={this.getValue()}
           onFocus={this.setFocusState.bind(this, true)}
           onBlur={this.setFocusState.bind(this, false)}

--- a/src/components/search/search-box/src/SearchBox.tsx
+++ b/src/components/search/search-box/src/SearchBox.tsx
@@ -16,6 +16,7 @@ export interface SearchBoxProps extends SearchkitComponentProps {
   queryFields?:Array<string>
   autofocus?:boolean
   queryOptions?:any
+  id?: string
   prefixQueryFields?:Array<string>
 }
 
@@ -30,10 +31,12 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
   translations = SearchBox.translations
 
   static defaultProps = {
+    id: 'q',
     searchThrottleTime:200
   }
 
   static propTypes = defaults({
+    id:React.PropTypes.string,
     searchOnChange:React.PropTypes.bool,
     searchThrottleTime:React.PropTypes.number,
     queryFields:React.PropTypes.arrayOf(React.PropTypes.string),
@@ -65,12 +68,12 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
   }
 
   defineAccessor(){
-
-    return new QueryAccessor("q", {
-      prefixQueryFields:(this.props.searchOnChange ? (this.props.prefixQueryFields || this.props.queryFields) : false),
-      queryFields:this.props.queryFields || ["_all"],
+    const { id, prefixQueryFields, queryFields, searchOnChange, queryOptions } = this.props
+    return new QueryAccessor(id, {
+      prefixQueryFields:(searchOnChange ? (prefixQueryFields || queryFields) : false),
+      queryFields:queryFields || ["_all"],
       queryOptions:assign({
-      }, this.props.queryOptions)
+      }, queryOptions)
     })
   }
 

--- a/src/core/AccessorManager.ts
+++ b/src/core/AccessorManager.ts
@@ -45,7 +45,7 @@ export class AccessorManager {
 
   add(accessor){
     if(accessor instanceof StatefulAccessor){
-      if(accessor instanceof BaseQueryAccessor){
+      if(accessor instanceof BaseQueryAccessor && accessor.key == "q"){
         if(this.queryAccessor !== noopQueryAccessor){
           throw new Error("Only a single instance of BaseQueryAccessor is allowed")
         } else {

--- a/test/e2e/server/apps/playground/index.tsx
+++ b/test/e2e/server/apps/playground/index.tsx
@@ -227,6 +227,7 @@ class App extends React.Component<any, any> {
               <RangeFilter min={0} max={100} field="metaScore" id="metascore" title="Metascore" showHistogram={true}/>
               <RangeFilter min={0} max={10} field="imdbRating" id="imdbRating" title="IMDB Rating" showHistogram={true} rangeComponent={RangeSliderHistogramInput}/>
               <RefinementListFilter id="actors" title="Actors" field="actors.raw" size={10}/>
+              <SearchBox id="author_q" autofocus={false} searchOnChange={true} prefixQueryFields={["actors"]} queryFields={["actors"]}/>
               <RefinementListFilter translations={{"facets.view_more":"View more writers"}} id="writers" title="Writers" field="writers.raw" operator="OR" size={10}/>
               <RefinementListFilter id="countries" title="Countries" field="countries.raw" operator="OR" size={10}/>
               <NumericRefinementListFilter listComponent={Select} id="runtimeMinutes" title="Length" field="runtimeMinutes" options={[

--- a/test/e2e/server/apps/playground/index.tsx
+++ b/test/e2e/server/apps/playground/index.tsx
@@ -9,6 +9,8 @@ const {
   ItemList, CheckboxItemList, ItemHistogramList, Tabs, TagCloud, MenuFilter,
   renderComponent, PageSizeSelector, RangeSliderHistogramInput, Panel, PaginationSelect,
   
+  InputFilter,
+  
   TermQuery, RangeQuery, BoolMust
 } = require("../../../../../src")
 const host = "http://demo.searchkit.co/api/movies"
@@ -206,6 +208,7 @@ class App extends React.Component<any, any> {
                   TermQuery("type.raw", "Movie")
                 ])} />
               
+              <InputFilter id="author_q" title="Actors filter" placeholder="Search actors" searchOnChange={true} prefixQueryFields={["actors"]} queryFields={["actors"]}/>
               <MenuFilter field={"type.raw"} size={10} title="Movie Type" id="types" listComponent={listComponents[this.state.viewMode]}
                 containerComponent={
                 (props) => (
@@ -227,7 +230,6 @@ class App extends React.Component<any, any> {
               <RangeFilter min={0} max={100} field="metaScore" id="metascore" title="Metascore" showHistogram={true}/>
               <RangeFilter min={0} max={10} field="imdbRating" id="imdbRating" title="IMDB Rating" showHistogram={true} rangeComponent={RangeSliderHistogramInput}/>
               <RefinementListFilter id="actors" title="Actors" field="actors.raw" size={10}/>
-              <SearchBox id="author_q" autofocus={false} searchOnChange={true} prefixQueryFields={["actors"]} queryFields={["actors"]}/>
               <RefinementListFilter translations={{"facets.view_more":"View more writers"}} id="writers" title="Writers" field="writers.raw" operator="OR" size={10}/>
               <RefinementListFilter id="countries" title="Countries" field="countries.raw" operator="OR" size={10}/>
               <NumericRefinementListFilter listComponent={Select} id="runtimeMinutes" title="Length" field="runtimeMinutes" options={[

--- a/theming/components.scss
+++ b/theming/components.scss
@@ -24,6 +24,7 @@
 
 @import "components/hierarchical-menu-filter.scss";
 @import "components/hierarchical-refinement-filter.scss";
+@import "components/input-filter.scss";
 @import "components/numeric-refinement-list-filter.scss";
 @import "components/refinement-list-filter.scss";
 @import "components/selected-filters.scss";

--- a/theming/components/_input-filter.scss
+++ b/theming/components/_input-filter.scss
@@ -1,0 +1,55 @@
+@import "../vars.scss";
+
+.sk-input-filter {
+  flex:auto;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+
+  form {
+    display:flex;
+    margin:0;
+    position:relative;
+  }
+
+  &__icon {
+    flex:0 20px 20px;
+    margin-top:6px;
+    margin-left:10px;
+    &:before {
+      content:"";
+      background:url(images/search.svg) no-repeat top left;
+      background-size: contain;
+      height:20px;
+      width:20px;
+      display: block;
+    }
+    opacity:0.3;
+  }
+
+  &__text {
+    padding:7px;
+    width:100%;
+    flex:3;
+    font-size:14px;
+    border:none;
+    &:focus {
+      outline:0;
+    }
+  }
+
+  &__action {
+    height:30px;
+    visibility: hidden;
+  }
+
+  &__loader {
+    flex:0 20px 20px;
+    align-self: flex-end;
+    margin:5px 10px;
+
+    &.is-hidden {
+      display:none;
+    }
+  }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
     "./src/components/search/filters/hierarchical-menu-filter/test/HierarchicalMenuFilterSpec.tsx",
     "./src/components/search/filters/hierarchical-refinement-filter/src/HierarchicalRefinementFilter.tsx",
     "./src/components/search/filters/hierarchical-refinement-filter/test/HierarchicalRefinementFilterSpec.tsx",
+    "./src/components/search/filters/input-filter/InputFilter.tsx",
     "./src/components/search/filters/numeric-refinement-list-filter/src/NumericRefinementListFilter.tsx",
     "./src/components/search/filters/numeric-refinement-list-filter/test/NumericRefinementListFilterSpec.tsx",
     "./src/components/search/filters/range-filter/src/RangeFilter.tsx",


### PR DESCRIPTION
Simple test to see if multiple searchboxes could be used.
The only change is to have a default `id="q"` for the searchbox, and consider that one as the default query accessor. Extra searchboxes can be added and used as filters.

Tested be adding another one in the facet sidebar : 
```jsx
<SearchBox id="author_q" 
    autofocus={false} 
    searchOnChange={true} 
    prefixQueryFields={["actors"]} 
    queryFields={["actors"]}/>
```

Works well (minus CSS styling)