### PR TITLE
add protractor to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "^2.1.4",
     "postcss-loader": "^0.8.2",
+    "protractor": "^3.2.1",
     "react-addons-test-utils": "^0.14.6",
     "react-dom": "^0.14.6",
     "sass-loader": "^3.1.2",


### PR DESCRIPTION
Missing dependency results in `protractor not found` when running `npm run test:e2e`