### PR TITLE
Add Elastic Cloud as hosted Elasticsearch provider

### DIFF
--- a/docs/setup/elasticsearch.md
+++ b/docs/setup/elasticsearch.md
@@ -6,6 +6,7 @@ Searchkit can use a cloud based elasticsearch instance. If using in production, 
 
 ### Hosting providers
 
+- [Elastic Cloud](https://www.elastic.co/cloud)
 - [qbox.io](https://qbox.io)
 - [search.ly](http://searchly.com)
 - [Amazon Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/)


### PR DESCRIPTION
Added link to Elastic Cloud (formerly known as Found), a hosted and managed Elasticsearch service from Elastic, the company behind Elasticsearch, Logstash, Kibana and Beats. 

I don't want to suggest that you should promote any particular service, so please feel free to re-order. Alphabetical ordering might be the most fair? :)