### PR TITLE
Fix FacetFilter 'View All' link edge case

### DIFF
--- a/src/__test__/core/accessors/FacetAccessorSpec.ts
+++ b/src/__test__/core/accessors/FacetAccessorSpec.ts
@@ -111,6 +111,13 @@ describe("FacetAccessor", ()=> {
       expect(this.accessor.getMoreSizeOption()).toEqual({size:30, label:"View all"})
     })
 
+    it("getMoreSizeOption - view all page size equals total", () => {
+      this.accessor.getCount = () => {
+        return 70
+      }
+      expect(this.accessor.getMoreSizeOption()).toEqual({size:70, label:"View all"})
+    })
+
     it("getMoreSizeOption - view less", () => {
       this.accessor.getCount = () => {
         return 30

--- a/src/core/accessors/FacetAccessor.ts
+++ b/src/core/accessors/FacetAccessor.ts
@@ -79,7 +79,7 @@ export class FacetAccessor extends FilterBasedAccessor<ArrayState> {
 
     if (total <= this.size) {
       option = {size:this.defaultSize, label:this.translate("facets.view_less")}
-    } else if ((this.size + facetsPerPage) > total) {
+    } else if ((this.size + facetsPerPage) >= total) {
       option = {size:total, label:this.translate("facets.view_all")}
     } else if ((this.size + facetsPerPage) < total) {
       option = {size:this.size + facetsPerPage, label:this.translate("facets.view_more")}


### PR DESCRIPTION
This is a really simple fix for a minor bug where the View more/all link sometimes doesn't appear below a refinement list filter.

There was an edge case where `this.size + facetsPerPage == total` - this slips in between the 'view all' and 'view more' options, and therefore neither was shown. This commit just ensures the 'View All' link is shown in this case.