### PR TITLE
inject missing selected filters

### DIFF
--- a/docs/components/navigation/menu.md
+++ b/docs/components/navigation/menu.md
@@ -69,6 +69,8 @@ class App extends React.Component {
   - `type:children` requires `options.childType` provided
   - see [Field Options](../../core/FieldOptions.md)
 - `countFormatter` *((count:number)=> number|string)* A optional function to format the doc counts
+- `bucketsTransform` *((buckets:Array)=> transformedBuckets)* A optional function to transform the buckets used for the aggregation, can be used to sort the list or to inject new facets.
+
 
 ## List Component examples
 

--- a/docs/components/navigation/refinement-list.md
+++ b/docs/components/navigation/refinement-list.md
@@ -73,6 +73,8 @@ class App extends SearchkitComponent {
   - `type:children` requires `options.childType` provided
   - see [Field Options](../../core/FieldOptions.md)
 - `countFormatter` *((count:number)=> number|string)* A optional function to format the doc counts
+- `bucketsTransform` *((buckets:Array)=> transformedBuckets)* A optional function to transform the buckets used for the aggregation, can be used to sort the list or to inject new facets.
+
 
 ## Translations
 - `facets.view_more` - View more

--- a/src/__test__/core/accessors/FacetAccessorSpec.ts
+++ b/src/__test__/core/accessors/FacetAccessorSpec.ts
@@ -48,6 +48,10 @@ describe("FacetAccessor", ()=> {
         {key:"b", doc_count:2}
       ])
 
+    // test raw buckets referential equality
+    expect(this.accessor.getBuckets())
+      .toBe(this.accessor.getRawBuckets())
+
     this.accessor.state = this.accessor.state.setValue(["a", "c"])
     expect(this.accessor.getBuckets())
       .toEqual([

--- a/src/__test__/core/accessors/FacetAccessorSpec.ts
+++ b/src/__test__/core/accessors/FacetAccessorSpec.ts
@@ -55,10 +55,16 @@ describe("FacetAccessor", ()=> {
     this.accessor.state = this.accessor.state.setValue(["a", "c"])
     expect(this.accessor.getBuckets())
       .toEqual([
-        {key:"c"},
-        {key:"a", doc_count:1},
+        {key:"c", missing:true, selected:true},
+        {key:"a", doc_count:1, selected:true},
         {key:"b", doc_count:2}
       ])
+    this.accessor.options.bucketsTransform = (buckets)=> {
+      return buckets.slice(0,1)
+    }
+    expect(this.accessor.getBuckets()).toEqual([
+      {key:"c", missing:true, selected:true}
+    ])
   })
 
   it("getCount()", ()=> {

--- a/src/__test__/core/accessors/FacetAccessorSpec.ts
+++ b/src/__test__/core/accessors/FacetAccessorSpec.ts
@@ -35,12 +35,26 @@ describe("FacetAccessor", ()=> {
     this.accessor.results = {
       aggregations:{
         genre1:{
-          genre:{buckets:[1,2]}
+          genre:{buckets:[
+            {key:"a", doc_count:1},
+            {key:"b", doc_count:2}
+          ]}
         }
       }
     }
     expect(this.accessor.getBuckets())
-      .toEqual([1,2])
+      .toEqual([
+        {key:"a", doc_count:1},
+        {key:"b", doc_count:2}
+      ])
+
+    this.accessor.state = this.accessor.state.setValue(["a", "c"])
+    expect(this.accessor.getBuckets())
+      .toEqual([
+        {key:"c"},
+        {key:"a", doc_count:1},
+        {key:"b", doc_count:2}
+      ])
   })
 
   it("getCount()", ()=> {

--- a/src/__test__/core/accessors/FacetAccessorSpec.ts
+++ b/src/__test__/core/accessors/FacetAccessorSpec.ts
@@ -58,13 +58,7 @@ describe("FacetAccessor", ()=> {
         {key:"c", missing:true, selected:true},
         {key:"a", doc_count:1, selected:true},
         {key:"b", doc_count:2}
-      ])
-    this.accessor.options.bucketsTransform = (buckets)=> {
-      return buckets.slice(0,1)
-    }
-    expect(this.accessor.getBuckets()).toEqual([
-      {key:"c", missing:true, selected:true}
-    ])
+      ])    
   })
 
   it("getCount()", ()=> {

--- a/src/components/search/filters/facet-filter/FacetFilter.tsx
+++ b/src/components/search/filters/facet-filter/FacetFilter.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../../ui"
 
 const defaults = require("lodash/defaults")
+const identity = require("lodash/identity")
 
 export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<T, any> {
   accessor: FacetAccessor
@@ -24,7 +25,8 @@ export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<
     size: 50,
     collapsable: false,
     showCount: true,
-    showMore: true
+    showMore: true,
+    bucketsTransform:identity
   }
 
   constructor(props){
@@ -33,11 +35,11 @@ export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<
   }
   getAccessorOptions(){
     const {
-      field, id, operator, title, include, exclude, bucketsTransform,
+      field, id, operator, title, include, exclude,
       size, translations, orderKey, orderDirection, fieldOptions
     } = this.props
     return {
-      id, operator, title, size, include, exclude, field, bucketsTransform,
+      id, operator, title, size, include, exclude, field,
       translations, orderKey, orderDirection, fieldOptions
     }
   }
@@ -85,7 +87,7 @@ export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<
   }
 
   getItems(){
-    return this.accessor.getBuckets()
+    return this.props.bucketsTransform(this.accessor.getBuckets())
   }
 
   render() {

--- a/src/components/search/filters/facet-filter/FacetFilter.tsx
+++ b/src/components/search/filters/facet-filter/FacetFilter.tsx
@@ -33,11 +33,11 @@ export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<
   }
   getAccessorOptions(){
     const {
-      field, id, operator, title, include, exclude,
+      field, id, operator, title, include, exclude, bucketsTransform,
       size, translations, orderKey, orderDirection, fieldOptions
     } = this.props
     return {
-      id, operator, title, size, include, exclude, field,
+      id, operator, title, size, include, exclude, field, bucketsTransform,
       translations, orderKey, orderDirection, fieldOptions
     }
   }

--- a/src/components/search/filters/facet-filter/FacetFilter.unit.tsx
+++ b/src/components/search/filters/facet-filter/FacetFilter.unit.tsx
@@ -135,8 +135,7 @@ describe("Facet Filter tests", () => {
       "fieldOptions":{
         type:"embedded",
         field:"test"
-      },
-      "bucketsTransform":_.identity
+      }
     }))
   })
 
@@ -178,23 +177,24 @@ describe("Facet Filter tests", () => {
         listComponent={Toggle}
         itemComponent={(props)=> <ItemComponent {...props} showCount={true}/>}
         field="test" id="test id" title="test title"
+        bucketsTransform={(buckets)=> _.reverse(buckets)}
         searchkit={this.searchkit} />
     )
 
     expect(this.wrapper.html()).toEqual(jsxToHTML(
       <div title="test title" className="filter--test id">
         <div data-qa="options" className="sk-toggle">
-          <div className="sk-toggle-option sk-toggle__item" data-qa="option" data-key="test option 1">
-            <div data-qa="label" className="sk-toggle-option__text">test option 1 translated</div>
-            <div data-qa="count" className="sk-toggle-option__count">1</div>
+          <div className="sk-toggle-option sk-toggle__item" data-qa="option" data-key="test option 3">
+            <div data-qa="label" className="sk-toggle-option__text">test option 3</div>
+            <div data-qa="count" className="sk-toggle-option__count">3</div>
           </div>
           <div className="sk-toggle-option sk-toggle__item" data-qa="option" data-key="test option 2">
             <div data-qa="label" className="sk-toggle-option__text">test option 2</div>
             <div data-qa="count" className="sk-toggle-option__count">2</div>
           </div>
-          <div className="sk-toggle-option sk-toggle__item" data-qa="option" data-key="test option 3">
-            <div data-qa="label" className="sk-toggle-option__text">test option 3</div>
-            <div data-qa="count" className="sk-toggle-option__count">3</div>
+          <div className="sk-toggle-option sk-toggle__item" data-qa="option" data-key="test option 1">
+            <div data-qa="label" className="sk-toggle-option__text">test option 1 translated</div>
+            <div data-qa="count" className="sk-toggle-option__count">1</div>
           </div>
         </div>
         <div data-qa="show-more" className="sk-refinement-list__view-more-action">View all facets</div>

--- a/src/components/search/filters/facet-filter/FacetFilter.unit.tsx
+++ b/src/components/search/filters/facet-filter/FacetFilter.unit.tsx
@@ -49,7 +49,7 @@ describe("Facet Filter tests", () => {
         field="test" id="test id" title="test title" size={3} countFormatter={(count)=>"#"+count}
         include={"title"} exclude={["bad", "n/a"]} operator="OR"
         orderKey="_count" orderDirection="desc" translations={{"facets.view_all":"View all facets"}}
-        searchkit={this.searchkit} />
+        searchkit={this.searchkit} bucketsTransform={_.identity}/>
     )
 
     this.getViewMore = ()=> this.wrapper.find(".sk-refinement-list__view-more-action")
@@ -120,7 +120,7 @@ describe("Facet Filter tests", () => {
     expect(this.accessor.key).toBe("test")
     let options = this.accessor.options
 
-    expect(options).toEqual({
+    expect(options).toEqual(jasmine.objectContaining({
       "id": "test id",
       "field":"test",
       "title": "test title",
@@ -135,8 +135,9 @@ describe("Facet Filter tests", () => {
       "fieldOptions":{
         type:"embedded",
         field:"test"
-      }
-    })
+      },
+      "bucketsTransform":_.identity
+    }))
   })
 
   it("should work with a custom itemComponent", () => {

--- a/src/components/search/filters/facet-filter/FacetFilterProps.ts
+++ b/src/components/search/filters/facet-filter/FacetFilterProps.ts
@@ -29,6 +29,7 @@ export interface FacetFilterProps extends SearchkitComponentProps {
   showMore?:boolean
   fieldOptions?:FieldOptions,
   countFormatter?:(count:number)=> number | string
+  bucketsTransform?:Function
 }
 
 export const FacetFilterPropTypes = defaults({
@@ -57,5 +58,6 @@ export const FacetFilterPropTypes = defaults({
     type:React.PropTypes.oneOf(["embedded", "nested", "children"]).isRequired,
     options:React.PropTypes.object
   }),
-  countFormatter:React.PropTypes.func
+  countFormatter:React.PropTypes.func,
+  bucketsTransform:React.PropTypes.func
 },SearchkitComponent.propTypes)

--- a/src/components/search/filters/facet-filter/MenuFilter.unit.tsx
+++ b/src/components/search/filters/facet-filter/MenuFilter.unit.tsx
@@ -46,7 +46,7 @@ describe("MenuFilter", ()=> {
 
   it("expect accessor options to be correct", ()=> {
     expect(this.wrapper.node.props.listComponent).toBe(ItemList)
-    expect(this.accessor.options).toEqual({
+    expect(this.accessor.options).toEqual(jasmine.objectContaining({
       id:"color", field:"color", title:"Color", operator:"OR",
       translations:{"Red":"Red Translated"},
       size:10, facetsPerPage:50, orderKey:"_term",
@@ -55,7 +55,7 @@ describe("MenuFilter", ()=> {
         type:"embedded",
         field:"color"
       }
-    })
+    }))
   })
 
   it("getSelectedItems", ()=> {

--- a/src/core/accessors/FacetAccessor.ts
+++ b/src/core/accessors/FacetAccessor.ts
@@ -10,6 +10,8 @@ const assign = require("lodash/assign")
 const map = require("lodash/map")
 const omitBy = require("lodash/omitBy")
 const isUndefined = require("lodash/isUndefined")
+const keyBy = require("lodash/keyBy")
+const reject = require("lodash/reject")
 
 
 export interface FacetAccessorOptions {
@@ -65,11 +67,22 @@ export class FacetAccessor extends FilterBasedAccessor<ArrayState> {
     this.fieldContext = FieldContextFactory(this.options.fieldOptions)
   }
 
-  getBuckets(){
+  getRawBuckets(){
     return this.getAggregations([
       this.uuid,
       this.fieldContext.getAggregationPath(),
       this.key, "buckets"], [])
+  }
+
+  getBuckets(){
+    let rawBuckets = this.getRawBuckets()
+    let keyIndex = keyBy(rawBuckets, "key")
+    let inIndex = (filter)=> !!keyIndex[filter]
+    let missingFilters =map(
+      reject(this.state.getValue() || [], inIndex),
+      (key)=> ({key})
+    )
+    return missingFilters.concat(rawBuckets)
   }
 
   getDocCount(){

--- a/src/core/accessors/FacetAccessor.ts
+++ b/src/core/accessors/FacetAccessor.ts
@@ -30,7 +30,6 @@ export interface FacetAccessorOptions {
   min_doc_count?:number
   loadAggregations?: boolean
   fieldOptions?:FieldOptions
-  bucketsTransform?:Function
 }
 
 export interface ISizeOption {
@@ -67,8 +66,7 @@ export class FacetAccessor extends FilterBasedAccessor<ArrayState> {
     }
     this.options.fieldOptions = this.options.fieldOptions || {type:"embedded"}
     this.options.fieldOptions.field = this.key
-    this.fieldContext = FieldContextFactory(this.options.fieldOptions)
-    this.options.bucketsTransform = this.options.bucketsTransform || identity
+    this.fieldContext = FieldContextFactory(this.options.fieldOptions)    
   }
 
   getRawBuckets(){
@@ -95,7 +93,7 @@ export class FacetAccessor extends FilterBasedAccessor<ArrayState> {
     let buckets = (missingFilters.length > 0) ?
       missingFilters.concat(rawBuckets) : rawBuckets
 
-    return this.options.bucketsTransform(buckets)
+    return buckets
   }
 
   getDocCount(){

--- a/src/core/accessors/FacetAccessor.ts
+++ b/src/core/accessors/FacetAccessor.ts
@@ -82,7 +82,10 @@ export class FacetAccessor extends FilterBasedAccessor<ArrayState> {
       reject(this.state.getValue() || [], inIndex),
       (key)=> ({key})
     )
-    return missingFilters.concat(rawBuckets)
+    if(missingFilters.length > 0){
+      return missingFilters.concat(rawBuckets)
+    }
+    return rawBuckets
   }
 
   getDocCount(){


### PR DESCRIPTION
- Inject missing selected filters to the top of a category
- add bucketsTransform property to RefinementList + Menu
- Replicate by selecting a facet + using search input box 