### PR TITLE
Fix disappearing Pagination with lodash 4.14.1

### DIFF
--- a/src/components/search/pagination/src/Pagination.tsx
+++ b/src/components/search/pagination/src/Pagination.tsx
@@ -78,7 +78,7 @@ export class Pagination extends SearchkitComponent<PaginationProps, any> {
 
   getTotalPages():number {
     return Math.ceil(
-      get(this.getResults(), ".hits.total", 1)
+      get(this.getResults(), "hits.total", 1)
       /
       get(this.getQuery(), "query.size", 10)
     );


### PR DESCRIPTION
I recently noticed a situation where the Pagination component is always disabled. I think it's an issue with lodash 4.14.1 but not lodash 4.13.1. I traced it to `getTotalPages` always returning 1. Removing the leading "." from the nested path provided to lodash `get` seems to fix it, and seems to be fine with lodash 4.13.1 too.

I suspect this is the relevant lodash change: lodash/lodash@c253e8d
