### PR TITLE
github requirements break npm shrinkwrap for your dependants

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "es6-promise": "^3.1.2",
     "history": "^2.1.1",
     "lodash": "4.6.1",
-    "qs": "ssetem/qs",
+    "qs": "6.2.1",
     "rc-slider": "3.3.2",
     "react": "^0.14.7",
     "react-addons-update": "^0.14.7"


### PR DESCRIPTION
If you really need legacy JS support you should publish qs-legacy or etc.
