### PR TITLE
Checkbox should be fixed size

### DIFF
--- a/theming/components/_filter-item.scss
+++ b/theming/components/_filter-item.scss
@@ -14,6 +14,7 @@
 
   input#{&}__checkbox {
     margin: 5px 5px 0 1px;
+    flex: 0 0 15px;
   }
 
   &.is-active &__text {


### PR DESCRIPTION
When filter option name is too long, checkbox shouldn't shrink

Currently, checkbox shrinks for long category names:

![screenshot from 2016-09-26 05 45 30](https://cloud.githubusercontent.com/assets/361985/18821190/997b3d9a-83ac-11e6-8993-ac3aa11c5440.png)
