### PR TITLE
change filter to post filer

### DIFF
--- a/src/core/query/ImmutableQuery.ts
+++ b/src/core/query/ImmutableQuery.ts
@@ -34,7 +34,7 @@ export class ImmutableQuery {
       query.query = BoolMust(this.index.queries)
     }
     if(this.index.filters.length > 0) {
-      query.filter = BoolMust(this.index.filters)
+      query.post_filter = BoolMust(this.index.filters)
     }
     query.aggs = this.index.aggs
     query.size = this.index.size


### PR DESCRIPTION
This fixes filters for 5.x by using a post_filter instead of a filter. The results are exactly the same, but only post filters are supported with 5.x