### PR TITLE
Extending filters feature for NestedFieldContext

### DIFF
--- a/src/components/search/filters/facet-filter/FacetFilter.tsx
+++ b/src/components/search/filters/facet-filter/FacetFilter.tsx
@@ -26,7 +26,8 @@ export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<
     collapsable: false,
     showCount: true,
     showMore: true,
-    bucketsTransform:identity
+    bucketsTransform:identity,
+    customAccessor:null
   }
 
   constructor(props){
@@ -44,6 +45,9 @@ export class FacetFilter<T extends FacetFilterProps> extends SearchkitComponent<
     }
   }
   defineAccessor() {
+    if (this.props.customAccessor) {
+      return this.props.customAccessor.call(this);
+    }
     return new FacetAccessor(
       this.props.field, this.getAccessorOptions())
   }

--- a/src/components/search/filters/facet-filter/FacetFilterProps.ts
+++ b/src/components/search/filters/facet-filter/FacetFilterProps.ts
@@ -30,6 +30,7 @@ export interface FacetFilterProps extends SearchkitComponentProps {
   fieldOptions?:FieldOptions,
   countFormatter?:(count:number)=> number | string
   bucketsTransform?:Function
+  customAccessor?: Function
 }
 
 export const FacetFilterPropTypes = defaults({

--- a/src/components/search/search-box/SearchBox.tsx
+++ b/src/components/search/search-box/SearchBox.tsx
@@ -119,7 +119,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
       return input
     }
   }
-  
+
   getAccessorValue(){
     return (this.accessor.state.getValue() || "") + ""
   }
@@ -139,11 +139,11 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
     if (!focused){
       const { input } = this.state
       if (this.props.blurAction == "search"
-        && !isUndefined(input) 
+        && !isUndefined(input)
         && input != this.getAccessorValue()){
         this.searchQuery(input)
       }
-      this.setState({ 
+      this.setState({
         focused,
         input: undefined // Flush (should use accessor's state now)
       })
@@ -166,7 +166,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
           value={this.getValue()}
           onFocus={this.setFocusState.bind(this, true)}
           onBlur={this.setFocusState.bind(this, false)}
-          ref="queryField"
+          /*ref="queryField"*/
           autoFocus={this.props.autofocus}
           onInput={this.onChange.bind(this)}/>
           <input type="submit" value="search" className={block("action")} data-qa="submit"/>

--- a/src/core/SearchkitManager.ts
+++ b/src/core/SearchkitManager.ts
@@ -25,7 +25,8 @@ export interface SearchkitOptions {
   httpHeaders?:Object,
   basicAuth?:string,
   transport?:ESTransport,
-  searchUrlPath?:string
+  searchUrlPath?:string,
+  withCredentials?:boolean,
 }
 
 export class SearchkitManager {
@@ -71,7 +72,8 @@ export class SearchkitManager {
     this.transport = this.options.transport || new AxiosESTransport(host, {
       headers:this.options.httpHeaders,
       basicAuth:this.options.basicAuth,
-      searchUrlPath:this.options.searchUrlPath
+      searchUrlPath:this.options.searchUrlPath,
+      withCredentials:this.options.withCredentials
     })
     this.accessors = new AccessorManager()
 		this.registrationCompleted = new Promise((resolve)=>{

--- a/src/core/accessors/Accessor.ts
+++ b/src/core/accessors/Accessor.ts
@@ -3,6 +3,7 @@ import {SearchkitManager} from "../SearchkitManager";
 import {Utils} from "../support"
 const get = require("lodash/get")
 const compact = require("lodash/compact")
+const flatten = require("lodash/flatten")
 
 export class Accessor {
   searchkit:SearchkitManager
@@ -54,7 +55,7 @@ export class Accessor {
 
   getAggregations(path, defaultValue){
     const results = this.getResults()
-    const getPath = compact(['aggregations',...path])
+    const getPath = compact(flatten(['aggregations', ...path]))
     return get(results, getPath, defaultValue)
   }
 

--- a/src/core/query/CustomAggregator.ts
+++ b/src/core/query/CustomAggregator.ts
@@ -1,0 +1,20 @@
+
+ export interface ICustomAggregator {
+   getAggregationPath():Array<any>|String
+   getAggregation(fieldContext, ...aggregations):any[]
+ }
+
+export class CustomAggregator<ICustomAggregator> {
+    constructor(public path:any, public aggregator:any) {
+      this.path = path;
+      this.aggregator = aggregator;
+    }
+
+    getAggregationPath() {
+        return this.path;
+    }
+
+    getAggregation(fieldContext, ...aggregations) {
+        return this.aggregator(fieldContext, ...aggregations);
+    }
+}

--- a/src/core/query/CustomAggregator.ts
+++ b/src/core/query/CustomAggregator.ts
@@ -1,7 +1,7 @@
 
  export interface ICustomAggregator {
    getAggregationPath():Array<any>|String
-   getAggregation(fieldContext, ...aggregations):any[]
+   getAggregations(fieldContext, ...aggregations):any[]
  }
 
 export class CustomAggregator<ICustomAggregator> {
@@ -14,7 +14,7 @@ export class CustomAggregator<ICustomAggregator> {
         return this.path;
     }
 
-    getAggregation(fieldContext, ...aggregations) {
+    getAggregations(fieldContext, ...aggregations) {
         return this.aggregator(fieldContext, ...aggregations);
     }
 }

--- a/src/core/query/field_context/FieldContext.ts
+++ b/src/core/query/field_context/FieldContext.ts
@@ -1,9 +1,23 @@
 import {FieldOptions} from "./FieldOptions"
+import {ICustomAggregator} from "../CustomAggregator"
+
+const get = require("lodash/get")
 
 export abstract class FieldContext {
-  constructor(public fieldOptions:FieldOptions){
+  customAggregator:ICustomAggregator
 
+  constructor(public fieldOptions:FieldOptions){
+    this.customAggregator = get(fieldOptions, "customAggregator", null)
   }
+
+  getCustomAggregator() {
+    return this.customAggregator;
+  }
+
+  getContextFilter(){
+    return get(this.fieldOptions, "filter", {});
+  }
+
   abstract getAggregationPath():any
   abstract wrapAggregations(...aggs):Array<any>
   abstract wrapFilter(filter:any):any

--- a/src/core/query/field_context/FieldOptions.ts
+++ b/src/core/query/field_context/FieldOptions.ts
@@ -1,5 +1,9 @@
+import {ICustomAggregator} from "../CustomAggregator"
+
 export interface FieldOptions {
   type:String,
   field?:String,
   options?:any
+  filter?:any
+  customAggregator?:ICustomAggregator
 }

--- a/src/core/query/field_context/NestedFieldContext.ts
+++ b/src/core/query/field_context/NestedFieldContext.ts
@@ -11,6 +11,10 @@ export class NestedFieldContext extends FieldContext {
     }
   }
 
+  getFilter(){
+    return {};
+  }
+
   getAggregationPath(){
     return "inner"
   }

--- a/src/core/query/field_context/NestedFieldContext.ts
+++ b/src/core/query/field_context/NestedFieldContext.ts
@@ -19,17 +19,22 @@ export class NestedFieldContext extends FieldContext {
 
   wrapAggregations(...aggregations){
     return this.getCustomAggregator()
-      ? this.getCustomAggregator().getAggregation(this, ...aggregations)
-      : [NestedBucket(
-          "inner",
-          this.fieldOptions.options.path,
-          FilterBucket(
-            "filtered.aggs",
-            this.getContextFilter(),
-            ...aggregations
-          )
-        )];
+      ? this.getCustomAggregator().getAggregations(this, ...aggregations)
+      : this.getAggregations(...aggregations);
   }
+
+  getAggregations(...aggregations) {
+    return [NestedBucket(
+      "inner",
+      this.fieldOptions.options.path,
+      FilterBucket(
+        "filtered.aggs",
+        this.getContextFilter(),
+        ...aggregations
+      )
+    )];
+  }
+
   wrapFilter(filter){
     return NestedQuery(
       this.fieldOptions.options.path,

--- a/src/core/query/field_context/NestedFieldContext.ts
+++ b/src/core/query/field_context/NestedFieldContext.ts
@@ -1,5 +1,5 @@
 import {FieldContext} from './FieldContext';
-import {NestedBucket, NestedQuery} from "../query_dsl"
+import {NestedBucket, NestedQuery, FilterBucket} from "../query_dsl"
 const get = require("lodash/get")
 
 export class NestedFieldContext extends FieldContext {
@@ -11,20 +11,24 @@ export class NestedFieldContext extends FieldContext {
     }
   }
 
-  getFilter(){
-    return {};
+  getContextFilter(){
+    return get(this.fieldOptions, "options.filter", null);
   }
 
   getAggregationPath(){
-    return "inner"
+    return ["inner", "filtered.aggs"];
   }
 
   wrapAggregations(...aggregations){
     return [NestedBucket(
       "inner",
       this.fieldOptions.options.path,
-      ...aggregations
-    )]
+      FilterBucket(
+        "filtered.aggs",
+        this.fieldOptions.options.filter || {},
+        ...aggregations
+      )
+    )];
   }
   wrapFilter(filter){
     return NestedQuery(

--- a/src/core/query/field_context/NestedFieldContext.ts
+++ b/src/core/query/field_context/NestedFieldContext.ts
@@ -11,24 +11,24 @@ export class NestedFieldContext extends FieldContext {
     }
   }
 
-  getContextFilter(){
-    return get(this.fieldOptions, "options.filter", null);
-  }
-
   getAggregationPath(){
-    return ["inner", "filtered.aggs"];
+    return this.getCustomAggregator()
+      ? this.getCustomAggregator().getAggregationPath()
+      : ["inner", "filtered.aggs"];
   }
 
   wrapAggregations(...aggregations){
-    return [NestedBucket(
-      "inner",
-      this.fieldOptions.options.path,
-      FilterBucket(
-        "filtered.aggs",
-        this.fieldOptions.options.filter || {},
-        ...aggregations
-      )
-    )];
+    return this.getCustomAggregator()
+      ? this.getCustomAggregator().getAggregation(this, ...aggregations)
+      : [NestedBucket(
+          "inner",
+          this.fieldOptions.options.path,
+          FilterBucket(
+            "filtered.aggs",
+            this.getContextFilter(),
+            ...aggregations
+          )
+        )];
   }
   wrapFilter(filter){
     return NestedQuery(

--- a/src/core/query/index.ts
+++ b/src/core/query/index.ts
@@ -1,4 +1,5 @@
 export * from "./ImmutableQuery"
+export * from "./CustomAggregator"
 export * from "./query_dsl"
 export * from "./SelectedFilter"
 export * from "./field_context"

--- a/src/core/query/query_dsl/compound/BoolQueries.ts
+++ b/src/core/query/query_dsl/compound/BoolQueries.ts
@@ -28,7 +28,7 @@ function flattenBool(operator, arr) {
 
 function boolHelper(val, operator){
   const isArr = isArray(val)
-  if (isArr) {
+  if (isArr && val.lenght > 1) {
     // Remove empty filters
     val = filter(val, f => !isEmpty(f))
     if (val.length === 1) {
@@ -40,6 +40,9 @@ function boolHelper(val, operator){
       && (findIndex(val, isBoolOp.bind(null, operator)) != -1)) {
       val = flattenBool(operator, val)
     }
+  }
+  else if (isArr && val.lenght === 1) {
+    val = val[0];
   }
   return {
     bool:{

--- a/src/core/transport/AxiosESTransport.ts
+++ b/src/core/transport/AxiosESTransport.ts
@@ -1,13 +1,7 @@
 import * as axios from "axios"
 import {ImmutableQuery} from "../query"
-import {ESTransport} from "./ESTransport";
+import {ESTransport, ESTransportOptions} from "./ESTransport";
 const defaults = require("lodash/defaults")
-
-export interface ESTransportOptions {
-  headers?:Object,
-  basicAuth?:string,
-  searchUrlPath?:string
-}
 
 export class AxiosESTransport extends ESTransport{
   static timeout = 5000
@@ -18,6 +12,7 @@ export class AxiosESTransport extends ESTransport{
     super()
     this.options = defaults(options, {
       headers:{},
+      withCredentials: false,
       searchUrlPath:"/_search"
     })
     if(this.options.basicAuth){
@@ -27,7 +22,8 @@ export class AxiosESTransport extends ESTransport{
     this.axios = axios.create({
       baseURL:this.host,
       timeout:AxiosESTransport.timeout,
-      headers:this.options.headers
+      headers:this.options.headers,
+      withCredentials: this.options.withCredentials
     })
   }
 

--- a/src/core/transport/ESTransport.ts
+++ b/src/core/transport/ESTransport.ts
@@ -1,3 +1,10 @@
+export interface ESTransportOptions {
+  headers?:Object,
+  basicAuth?:string,
+  searchUrlPath?:string
+  withCredentials?:boolean
+}
+
 export abstract class ESTransport {
   abstract search(query:Object):any
 }


### PR DESCRIPTION
Regarding to: 

http://stackoverflow.com/questions/40893401/elasticsearch-how-to-filter-nested-aggregation-bucket

1. I've fixed nested field context to allow filtering aggregation fields while it was not possible using post filter on the same level as nested path was created.
2. I've also added customAccessor attribute just to overwrite accessor without extending component.