### PR TITLE
Fix broken markdown in indexing documentation

### DIFF
--- a/docs/server/indexing.md
+++ b/docs/server/indexing.md
@@ -45,7 +45,8 @@ Out the box, elasticsearch uses the default [standard analyzer](https://www.elas
       }
     }
   }
-}```
+}
+```
 
 ## Searchkit Mapping best practices
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/193864/22180928/26051b72-e0ba-11e6-9fce-5af0bbe3769a.png)
