### PR TITLE
Hierarchical Menu filter size has a default of 20 

### DIFF
--- a/src/components/search/filters/hierarchical-menu-filter/src/HierarchicalMenuFilter.tsx
+++ b/src/components/search/filters/hierarchical-menu-filter/src/HierarchicalMenuFilter.tsx
@@ -25,7 +25,8 @@ export class HierarchicalMenuFilter extends SearchkitComponent<HierarchicalMenuF
 	public accessor:HierarchicalFacetAccessor
 
 	static defaultProps = {
-		countFormatter:identity
+		countFormatter:identity,
+		size: 20
 	}
 	static propTypes = defaults({
 		id:React.PropTypes.string.isRequired,
@@ -45,7 +46,7 @@ export class HierarchicalMenuFilter extends SearchkitComponent<HierarchicalMenuF
 	}
 
 	defineAccessor() {
-		const {id, title, fields, size=0, orderKey, orderDirection} = this.props
+		const {id, title, fields, size, orderKey, orderDirection} = this.props
 		return new HierarchicalFacetAccessor(id, {
 			id, title, fields, size, orderKey, orderDirection
 		})

--- a/src/components/search/filters/hierarchical-menu-filter/test/HierarchicalMenuFilterSpec.tsx
+++ b/src/components/search/filters/hierarchical-menu-filter/test/HierarchicalMenuFilterSpec.tsx
@@ -42,7 +42,7 @@ describe("MenuFilter tests", () => {
     expect(this.accessor.key).toBe("categories")
     expect(this.accessor.options).toEqual({
       id: 'categories', title: 'Categories',
-      fields: ['lvl1', 'lvl2'], size: 0,
+      fields: ['lvl1', 'lvl2'], size: 20,
       orderKey:"_term", orderDirection:"asc"
     })
   })


### PR DESCRIPTION
issue #391 spotted that if a size is not specified, its default is 0 which in ES5 now is invalid. This small update defaults it to 20.