### PR TITLE
Add withCredentials support

### DIFF
--- a/src/__test__/core/SearchkitManagerSpec.ts
+++ b/src/__test__/core/SearchkitManagerSpec.ts
@@ -47,8 +47,13 @@ describe("SearchkitManager", ()=> {
       .toEqual(jasmine.any(AxiosESTransport))
     expect(this.searchkit.transport.options.headers).toEqual(
       jasmine.objectContaining({
-        "Content-Type":"application/json",
-        "Authorization":jasmine.any(String)
+        "Content-Type":"application/json"
+      })
+    )
+    expect(this.searchkit.transport.axios.defaults.auth).toEqual(
+      jasmine.objectContaining({
+        "username":"key",
+        "password":"val"
       })
     )
     expect(this.searchkit.query).toEqual(new ImmutableQuery())

--- a/src/__test__/core/transport/AxiosESTransportSpec.ts
+++ b/src/__test__/core/transport/AxiosESTransportSpec.ts
@@ -34,9 +34,10 @@ describe("AxiosESTransport", ()=> {
       timeout: 10000
     })
     expect(transport.options.headers).toEqual({
-      "Content-Type":"application/json",
-      "Authorization":"Basic " + btoa("key:val")
+      "Content-Type":"application/json"
     })
+    expect(transport.axios.defaults.auth.username).toBe("key")
+    expect(transport.axios.defaults.auth.password).toBe("value")
     expect(transport.options.timeout).toEqual(10000)
     expect(transport.options.searchUrlPath).toBe("/_search/")
   })

--- a/src/core/transport/AxiosESTransport.ts
+++ b/src/core/transport/AxiosESTransport.ts
@@ -6,6 +6,7 @@ import {defaults} from "lodash"
 export interface ESTransportOptions {
   headers?:Object,
   basicAuth?:string,
+  withCredentials?:boolean,
   searchUrlPath?:string,
   timeout?: number
 }
@@ -23,8 +24,8 @@ export class AxiosESTransport extends ESTransport{
       timeout: AxiosESTransport.timeout
     })
 
-    const auth = this.options.basicAuth ? AxiosESTransport.parseAuth(this.options.basicAuth) : {}
-    const config = defaults(auth, {
+    const credentials = AxiosESTransport.parseCredentials(this.options)
+    const config = defaults(credentials, {
       baseURL:this.host,
       timeout:this.options.timeout,
       headers:this.options.headers
@@ -41,8 +42,16 @@ export class AxiosESTransport extends ESTransport{
     return response.data
   }
 
-  private static parseAuth(basicAuth: string): any {
-    const credentials = basicAuth.split(":")
-    return { username: credentials[0], password: credentials[1] }
+  private static parseCredentials(options: ESTransportOptions): any {
+    let credentials = {}
+    if (options.basicAuth !== undefined) {
+       const parsed = options.basicAuth.split(":")
+       const auth = { username: parsed[0], parsed: credentials[1] }
+       credentials['auth'] = auth
+    }
+    if (options.withCredentials !== undefined) {
+       credentials['withCredentials'] = options.withCredentials
+    }
+    return credentials
   }
 }

--- a/src/core/transport/AxiosESTransport.ts
+++ b/src/core/transport/AxiosESTransport.ts
@@ -23,17 +23,13 @@ export class AxiosESTransport extends ESTransport{
       timeout: AxiosESTransport.timeout
     })
 
-    if(this.options.basicAuth){
-      this.options.headers["Authorization"] = (
-        "Basic " + btoa(this.options.basicAuth))
-    }
-
-    this.axios = axios.create({
+    const auth = this.options.basicAuth ? AxiosESTransport.parseAuth(this.options.basicAuth) : {}
+    const config = defaults(auth, {
       baseURL:this.host,
       timeout:this.options.timeout,
       headers:this.options.headers
     })
-
+    this.axios = axios.create(config)
   }
 
   search(query:Object): Promise<AxiosResponse> {
@@ -45,4 +41,8 @@ export class AxiosESTransport extends ESTransport{
     return response.data
   }
 
+  private static parseAuth(basicAuth: string): any {
+    const credentials = basicAuth.split(":")
+    return { username: credentials[0], password: credentials[1] }
+  }
 }


### PR DESCRIPTION
This is needed when your elasticsearch cluster is running with basic auth under a different domain: https://developer.mozilla.org/pt-BR/docs/Web/API/XMLHttpRequest/withCredentials.

I also changed the code to use the basic auth functionality exposed by axios instead of reimplementing it.

This is the code draft, happy to improve tests if the code is in the right direction.