### PR TITLE
Fix inline parameters declaration syntax.

### DIFF
--- a/src/components/ui/list/ListProps.ts
+++ b/src/components/ui/list/ListProps.ts
@@ -10,7 +10,7 @@ export interface ListProps {
   mod?: string
   className?: string
   showCount?: boolean
-  translate?: (string) => string
+  translate?: (s: string) => string
   multiselect?: boolean // if true, uses toggleItem, else uses setItems
 }
 

--- a/src/components/ui/range/RangeProps.ts
+++ b/src/components/ui/range/RangeProps.ts
@@ -13,7 +13,7 @@ export interface RangeProps {
   disabled?: boolean
   mod?: string
   className?: string
-  translate?: (string) => string
+  translate?: (s: string) => string
 }
 
 export const RangePropTypes = {

--- a/src/components/ui/range/RangeSlider.tsx
+++ b/src/components/ui/range/RangeSlider.tsx
@@ -11,7 +11,7 @@ import { PureRender } from "../../../core/react/pure-render"
 export interface RangeSliderProps extends RangeProps {
   step?: number
   marks?: Object
-  rangeFormatter?:(number)=> number | string
+  rangeFormatter?:(n: number)=> number | string
 }
 
 @PureRender


### PR DESCRIPTION
This fixes the following problems when consuming searchkit in typescript:

````
Error in /Users/davi/code/my-app/node_modules/searchkit/lib/src/components/ui/range/RangeSlider.d.ts
(8,23): error TS7006: Parameter 'number' implicitly has an 'any' type.

Error in /Users/davi/code/my-app/node_modules/searchkit/lib/src/components/ui/range/RangeProps.d.ts
(20,18): error TS7006: Parameter 'string' implicitly has an 'any' type.

Error in /Users/davi/code/my-app/node_modules/searchkit/lib/src/components/ui/list/ListProps.d.ts
(12,18): error TS7006: Parameter 'string' implicitly has an 'any' type.
````