### PR TITLE
Allows single element to be added as must condition

### DIFF
--- a/src/core/query/query_dsl/compound/BoolQueries.ts
+++ b/src/core/query/query_dsl/compound/BoolQueries.ts
@@ -32,8 +32,7 @@ function boolHelper(val, operator){
     // Remove empty filters
     val = filter(val, f => !isEmpty(f))
     if (val.length === 1) {
-      if (operator != "must_not") return val[0]
-      else val = val[0] // Unbox array
+      val = val[0] // Unbox array
     } else if (val.length === 0) {
       return {}
     } else if ((operator == "must" || operator == "should")


### PR DESCRIPTION
@joemcelroy @ssetem  not sure why `if (operator != "must_not") return val[0]` was implemented but this was producing issue when wanting to setup must query with single element. Did you encounter some issues ? @ssetem  What was purpose for putting this there ?