### PR TITLE
aggregation size cannot be 0 by default

### DIFF
--- a/docs/components/navigation/hierarchical-refinement-filter.md
+++ b/docs/components/navigation/hierarchical-refinement-filter.md
@@ -69,6 +69,7 @@ class App extends SearchkitComponent {
 - `id` *(string)*: id of component. Must be unique. Used as key for url serialization
 - `startLevel` *(number)*: Optional. Can specify the root level to start from.
 - `orderKey` *(string)*: Order key either using default sortable keys `_count` `_term` or using the `order` field e.g. `color.order`
+- `size` *(number)*: Optional. Number of buckets to return. Default value is 2^31 - 1.
 - `orderDirection` *(string)*: `asc` or `desc`
 - `translations` *(Object)*: An object of translations you wish to override. For more information on translations see [translate](../../core/Translate.md) page.
 - `mod` *(string)*: Optional. A custom BEM container class.

--- a/src/__test__/core/accessors/NestedFacetAccessorSpec.ts
+++ b/src/__test__/core/accessors/NestedFacetAccessorSpec.ts
@@ -2,7 +2,7 @@ import {
   FacetAccessor, ImmutableQuery,
   BoolMust, BoolShould, ArrayState, NestedFacetAccessor,
   NestedQuery, TermQuery, FilterBucket, NestedBucket, MinMetric,
-  TermsBucket
+  TermsBucket, DefaultNumberBuckets
 } from "../../../"
 
 import * as _ from "lodash"
@@ -59,7 +59,7 @@ describe("NestedFacetAccessor", ()=> {
       TermsBucket(
         "children",
         "taxonomy.value",
-        {size:0, order:{taxonomy_order:"desc"}},
+        {size:DefaultNumberBuckets, order:{taxonomy_order:"desc"}},
         MinMetric("taxonomy_order", "taxonomy.order")
       )
     )
@@ -69,7 +69,7 @@ describe("NestedFacetAccessor", ()=> {
     expect(this.accessor.getTermAggs()).toEqual(
       TermsBucket(
         "children", "taxonomy.value",
-        {size:0, order:{"_count":"asc"}}
+        {size:DefaultNumberBuckets, order:{"_count":"asc"}}
       )
     )
 
@@ -79,7 +79,7 @@ describe("NestedFacetAccessor", ()=> {
     expect(this.accessor.getTermAggs()).toEqual(
       TermsBucket(
         "children", "taxonomy.value",
-        {size:0, order:undefined}
+        {size:DefaultNumberBuckets, order:undefined}
       )
     )
 
@@ -128,7 +128,7 @@ describe("NestedFacetAccessor", ()=> {
     let termsBucket = TermsBucket(
       "children",
       "taxonomy.value",
-      {size:0, order:{taxonomy_order:"desc"}},
+      {size:DefaultNumberBuckets, order:{taxonomy_order:"desc"}},
       MinMetric("taxonomy_order", "taxonomy.order")
     )
     let expected = FilterBucket(

--- a/src/components/search/filters/hierarchical-refinement-filter/src/HierarchicalRefinementFilter.tsx
+++ b/src/components/search/filters/hierarchical-refinement-filter/src/HierarchicalRefinementFilter.tsx
@@ -8,17 +8,16 @@ import {
 	SearchkitComponentProps
 } from "../../../../../core"
 
-import {defaults} from "lodash"
-import {map} from "lodash"
-import {identity} from "lodash"
+import { defaults, map, identity } from "lodash"
 
 export interface HierarchicalRefinementFilterProps extends SearchkitComponentProps {
 	field:string
 	id:string
 	title:string
+	size?:number
   orderKey?:string
   orderDirection?:string
-  startLevel?:number,
+  startLevel?:number
 	countFormatter?:(count:number)=> number | string
 }
 
@@ -48,10 +47,24 @@ export class HierarchicalRefinementFilter extends SearchkitComponent<Hierarchica
 	}
 
 	defineAccessor() {
-		const {field, id, title, orderKey, orderDirection, startLevel} = this.props
+		const {
+			field,
+			id,
+			title,
+			size,
+			orderKey,
+			orderDirection,
+			startLevel } = this.props;
+
 		return new NestedFacetAccessor(id, {
-			field, id, title, orderKey, orderDirection, startLevel
-		})
+			field,
+			id,
+			title,
+			size,
+			orderKey,
+			orderDirection,
+			startLevel
+		});
 	}
 
 	addFilter(level, option) {

--- a/src/components/search/filters/hierarchical-refinement-filter/test/HierarchicalRefinementFilterSpec.tsx
+++ b/src/components/search/filters/hierarchical-refinement-filter/test/HierarchicalRefinementFilterSpec.tsx
@@ -10,7 +10,6 @@ import * as sinon from "sinon"
 describe("Refinement List Filter tests", () => {
 
   beforeEach(() => {
-
     this.searchkit = SearchkitManager.mock()
     spyOn(this.searchkit, "performSearch")
     this.wrapper = mount(
@@ -57,7 +56,6 @@ describe("Refinement List Filter tests", () => {
         return container;
       }
     }
-
   });
 
   it("should configure accessor correctly", ()=> {
@@ -67,6 +65,7 @@ describe("Refinement List Filter tests", () => {
       "id": "testid",
       "title": "test title",
       "field":"test",
+      "size": undefined,
       "orderKey":undefined,
       "orderDirection":undefined,
       "startLevel":undefined

--- a/src/core/query/query_dsl/aggregations/BucketAggregations.ts
+++ b/src/core/query/query_dsl/aggregations/BucketAggregations.ts
@@ -9,6 +9,10 @@ export interface TermsBucketOptions {
   min_doc_count?:number
 }
 
+// Emulates the maximum value an integer can have in Java
+// See: https://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html#MAX_VALUE
+export const DefaultNumberBuckets = Math.pow(2, 31) - 1;
+
 export function TermsBucket(key, field, options:TermsBucketOptions={}, ...childAggs){
   return AggsContainer(key, {
     terms:assign({field}, options)


### PR DESCRIPTION
fixes issue where nestedAccessor is 0 by default causing an issue for ES5. Affects Nested Filter. This is a merge of @juan-fdz-hawa  #429 changes