### PR TITLE
Hierarchical Menu Docs

### DIFF
--- a/docs/components/navigation/hierarchical-menu.md
+++ b/docs/components/navigation/hierarchical-menu.md
@@ -50,7 +50,7 @@ class App extends SearchkitComponent {
 
  render(){
     <div>
-      <HierarchicalMenuFilter fields={["categories_lvl1", "categories_lvl2", "categories_lvl3"]} title="Categories" id="categories"/>
+      <HierarchicalMenuFilter fields={["category.lvl1", "category.lvl2", "category.lvl3"]} title="Categories" id="categories"/>
     </div>
   }
 }


### PR DESCRIPTION
Updated the hierarchical menu docs page so that the code sample used consistent field names throughout; since it caused some confusion for a colleague recently.

With Elasticsearch 5 now released I was going to try to address the fact that [the `"string"` data type the docs recommend has been removed](https://www.elastic.co/blog/strings-are-dead-long-live-strings), but wasn't sure the best way to approach that. Happy to update this PR with a bit of guidance there.

In Elasticsearch 5.5.0 where string has been removed, I found that if no explicit mapping is created but data gets pushed in with the form:

```
"category": {
  "lvl1": "Appliances" 
  "lvl2": "Air Conditioners"
  "lvl3": "Window Air Conditioners"
}
```
The component functions fine if directed to the fields:

```
["category.lvl1.keyword", "category.lvl2.keyword", "category.lvl3.keyword"]
```
Thoughts on how/if that needs to be addressed?