### PR TITLE
Update PureRenderComponent.ts

### DIFF
--- a/src/core/react/pure-render/PureRenderComponent.ts
+++ b/src/core/react/pure-render/PureRenderComponent.ts
@@ -3,5 +3,7 @@ import {shouldPureComponentUpdate} from "./shouldPureComponentUpdate"
 import {PureRender} from "./PureRender"
 
 export class PureRenderComponent<T> extends React.Component<T, any> {
-  shouldComponentUpdate:Function= shouldPureComponentUpdate
+  shouldComponentUpdate(nextProps: any, nextState: any): boolean {
+    return shouldPureComponentUpdate.call(this, nextProps, nextState)
+  }
 }


### PR DESCRIPTION
My project uses TS 2.5. When I try to `tsc` it using searchkit in my project, I get the following error.

```
lib/src/core/react/pure-render/PureRenderComponent.d.ts(4,5): error TS2424: Class 'Component<T, any>' defines instance member function 'shouldComponentUpdate', but extended class 'PureRenderComponent<T>' defines it as instance member property.
```

This patch should fix that