### PR TITLE
Issue 427: add DateHistogramBucket and GeoboundsBucket aggregations

### DIFF
--- a/src/__test__/core/query/ImmutableQuerySpec.ts
+++ b/src/__test__/core/query/ImmutableQuerySpec.ts
@@ -148,7 +148,7 @@ describe("ImmutableQuery", ()=> {
     let query = this.query.setAggs(genreAggs).setAggs(authorAggs)
     expect(query.query.aggs).toEqual({
       "genre_filter": {
-        "filter": {},
+        "filter": {"match_all": {}},
         "aggs": {
           "genre_terms": {
             "terms": {
@@ -158,7 +158,7 @@ describe("ImmutableQuery", ()=> {
         }
       },
       "author_filter": {
-        "filter": {},
+        "filter": {"match_all": {}},
         "aggs": {
           "author_terms": {
             "terms": {

--- a/src/__test__/core/query/query_dsl/aggregations/BucketAggregationsSpec.ts
+++ b/src/__test__/core/query/query_dsl/aggregations/BucketAggregationsSpec.ts
@@ -1,9 +1,10 @@
 import {
   AggsContainer,
+  DateHistogramBucket,
   TermsBucket, RangeBucket,
   ChildrenBucket, FilterBucket,
   NestedBucket,SignificantTermsBucket,
-  GeohashBucket, HistogramBucket
+  GeohashBucket, GeoboundsBucket, HistogramBucket
 } from "../../../../../"
 import * as _ from "lodash"
 
@@ -105,4 +106,27 @@ describe("BucketAggregations", ()=> {
     this.expectAggs({histogram:{field:"price", interval:1}})
   })
 
+  it("GeoboundsBucket", ()=> {
+    this.aggs = GeoboundsBucket(
+      this.aggsKey, "location",
+      {precision:5},
+      this.childBucket
+    )
+    this.expectAggs({geo_bounds:{field:"location", precision:5}})
+  })
+
+  it("DateHistogramBucket", ()=> {
+    expect(DateHistogramBucket(this.aggsKey, "date_field")).toEqual({
+      [this.aggsKey]:{
+        date_histogram:{field:"date_field"}
+      }
+    })
+    this.aggs = DateHistogramBucket(
+      this.aggsKey,
+      "date_field",
+      {interval:"year"},
+      this.childBucket
+    )
+    this.expectAggs({date_histogram:{field:"date_field", interval:"year"}})
+  })
 })

--- a/src/core/query/query_dsl/aggregations/BucketAggregations.ts
+++ b/src/core/query/query_dsl/aggregations/BucketAggregations.ts
@@ -50,3 +50,11 @@ export function GeohashBucket(key, field, options, ...childAggs){
 export function HistogramBucket(key, field, options={}, ...childAggs){
   return AggsContainer(key, {histogram:assign({field}, options)}, childAggs)
 }
+
+export function GeoboundsBucket(key, field, options = {}, ...childAggs) {
+  return AggsContainer(key, { geo_bounds: assign({ field }, options) }, childAggs);
+}
+
+export function DateHistogramBucket(key, field, options = {}, ...childAggs) {
+  return AggsContainer(key, { date_histogram: assign({ field }, options) }, childAggs);
+}

--- a/src/core/query/query_dsl/aggregations/BucketAggregations.ts
+++ b/src/core/query/query_dsl/aggregations/BucketAggregations.ts
@@ -1,4 +1,5 @@
 import {assign} from "lodash"
+import {isEmpty} from "lodash"
 import {AggsContainer} from "./AggsContainer"
 
 export interface TermsBucketOptions {
@@ -32,6 +33,9 @@ export function ChildrenBucket(key, type, ...childAggs){
 }
 
 export function FilterBucket(key, filter, ...childAggs){
+  if (isEmpty(filter)) {
+    return AggsContainer(key, {filter: {match_all:{}}}, childAggs)
+  }
   return AggsContainer(key, {filter}, childAggs)
 }
 


### PR DESCRIPTION
I've used these two bucket aggregations in a private project for some time and thought it'd be nicer to have them directly in SearchKit.  This would fix isse #427.