### PR TITLE
Issue 423: prevent deprecation warning by replacing empty filter with match_all

### DIFF
--- a/src/__test__/core/query/ImmutableQuerySpec.ts
+++ b/src/__test__/core/query/ImmutableQuerySpec.ts
@@ -148,7 +148,7 @@ describe("ImmutableQuery", ()=> {
     let query = this.query.setAggs(genreAggs).setAggs(authorAggs)
     expect(query.query.aggs).toEqual({
       "genre_filter": {
-        "filter": {},
+        "filter": {"match_all": {}},
         "aggs": {
           "genre_terms": {
             "terms": {
@@ -158,7 +158,7 @@ describe("ImmutableQuery", ()=> {
         }
       },
       "author_filter": {
-        "filter": {},
+        "filter": {"match_all": {}},
         "aggs": {
           "author_terms": {
             "terms": {

--- a/src/core/query/query_dsl/aggregations/BucketAggregations.ts
+++ b/src/core/query/query_dsl/aggregations/BucketAggregations.ts
@@ -1,4 +1,5 @@
 import {assign} from "lodash"
+import {isEmpty} from "lodash"
 import {AggsContainer} from "./AggsContainer"
 
 export interface TermsBucketOptions {
@@ -32,6 +33,9 @@ export function ChildrenBucket(key, type, ...childAggs){
 }
 
 export function FilterBucket(key, filter, ...childAggs){
+  if (isEmpty(filter)) {
+    return AggsContainer(key, {filter: {match_all:{}}}, childAggs)
+  }
   return AggsContainer(key, {filter}, childAggs)
 }
 


### PR DESCRIPTION
This should prevent the warnings in issue #423.

Suppressing the `filters: {}` clause will not work. Therefore, it no filters are found, it is replace with the `match_all: {}` filter.

Tested this successfully in an own application.