### PR TITLE
Add shouldPerformSearch check, add defaultSize

### DIFF
--- a/docs/components/basics/hits.md
+++ b/docs/components/basics/hits.md
@@ -35,7 +35,7 @@ class App extends SearchkitComponent {
 ```
 
 ## Props
-- `hitsPerPage` *(Number)*: Number of results displayed per page
+- `hitsPerPage` *(Number)?*: Number of results displayed per page
 - `highlightFields` *(Array<string>)*: Array of highlighted fields. Any highlight matches will be returned in the result.highlight[fieldName]. See above for example.
 - `customHighlight` *(Object)*: Optional. Allows any custom highlight behavior to control the number of fragments, fragment sizes, and highlighter. Passed through directly to elasticsearch as the value for `highlight`. See the [elastic documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html) for further details.
 - `mod` *(string)*: Optional. A custom BEM container class.

--- a/docs/core/SearchkitManager.md
+++ b/docs/core/SearchkitManager.md
@@ -38,6 +38,8 @@ const searchkit = new SearchkitManager(host, {
 
 * **timeout** - A number value to override the default 5000ms response timeout. Optional.
 
+* **defaultSize** - Default size for elastic results, defaults to `20`
+
 ## Default Queries
 
 Sometimes we need to apply a default query which affects the entire search and is not serialized to the browser url.
@@ -88,4 +90,14 @@ let removalFn = searchkit.addResultsListener((results)=>{
 })
 
 //removalFn() if you want to stop listening
+```
+
+## shouldPerformSearch
+If you want to control whether Searchkit performs a search, you can provide a custom check function
+The `shouldPerformSearch` function is called with an instance of `ImmutableQuery`
+```typescript
+  //only search when there is a query string
+  this.searchkit.shouldPerformSearch = (query)=> {
+    return !!query.getQueryString()
+  }
 ```

--- a/src/__test__/core/AccessorManagerSpec.ts
+++ b/src/__test__/core/AccessorManagerSpec.ts
@@ -15,23 +15,21 @@ class StatelessPageAccessor extends Accessor {
 describe("AccessorManager", ()=> {
 
   beforeEach(()=> {
-    this.searchkit = SearchkitManager.mock()
-
+    this.accessors = new AccessorManager()
     this.accessor1 = new PaginationAccessor("p1")
     this.accessor2 = new PaginationAccessor("p2")
-    this.searchkit.addAccessor(this.accessor1)
-    this.searchkit.addAccessor(this.accessor2)
+    this.accessors.add(this.accessor1)
+    this.accessors.add(this.accessor2)
 
     this.accessor3 = new PaginationAccessor("p3")
     this.accessor4 = new PaginationAccessor("p4")
     this.accessor4b = new PaginationAccessor("p4")
-    this.searchkit.addAccessor(this.accessor3)
-    this.searchkit.addAccessor(this.accessor4)
-    this.searchkit.addAccessor(this.accessor4b)
+    this.accessors.add(this.accessor3)
+    this.accessors.add(this.accessor4)
+    this.accessors.add(this.accessor4b)
 
     this.accessor5 = new StatelessPageAccessor(50)
-    this.searchkit.addAccessor(this.accessor5)
-    this.accessors = this.searchkit.accessors
+    this.accessors.add(this.accessor5)    
   })
 
   it("constructor()", ()=> {
@@ -39,7 +37,7 @@ describe("AccessorManager", ()=> {
       this.accessor1, this.accessor2,
       this.accessor3, this.accessor4,
       this.accessor5
-    ])
+    ])    
     expect(new AccessorManager().accessors)
       .toEqual([])
   })
@@ -188,8 +186,7 @@ describe("AccessorManager", ()=> {
       .toBe(5)
 
     this.accessor5.setActive(false)
-    expect(this.accessors.buildQuery().getSize())
-      .toBe(0)
+    expect(this.accessors.buildQuery().getSize())     
 
   })
 

--- a/src/__test__/core/react/SearchkitComponentSpec.tsx
+++ b/src/__test__/core/react/SearchkitComponentSpec.tsx
@@ -3,6 +3,7 @@ import {
   SearchkitManager,
   Accessor,
   ImmutableQuery,
+  AccessorManager,
   block
 } from "../../../"
 
@@ -74,6 +75,7 @@ describe("SearchkitComponent", ()=> {
   it("componentWillMount()", ()=> {
     spyOn(this.component, "forceUpdate")
     let searchkit = SearchkitManager.mock()
+    searchkit.accessors = new AccessorManager()
     let accessor = new Accessor()
     this.component.defineAccessor = ()=> accessor
     spyOn(console, "warn")

--- a/src/components/search/filters/checkbox-filter/CheckboxFilter.unit.tsx
+++ b/src/components/search/filters/checkbox-filter/CheckboxFilter.unit.tsx
@@ -4,7 +4,7 @@ import {fastClick, hasClass, jsxToHTML, printPrettyHtml} from "../../../__test__
 import {CheckboxFilter} from "./CheckboxFilter";
 import {SearchkitManager, Utils} from "../../../../core";
 import {Toggle, ItemComponent} from "../../../ui";
-import { TermQuery } from "../../../../core";
+import { TermQuery, CheckboxFilterAccessor } from "../../../../core";
 
 import * as _ from "lodash"
 import * as sinon from "sinon";
@@ -25,7 +25,7 @@ describe("CheckboxFilter tests", () => {
       }
     })
 
-    this.accessor = this.searchkit.accessors.getAccessors()[0]
+    this.accessor = this.searchkit.getAccessorByType(CheckboxFilterAccessor)
   }
 
   beforeEach(() => {

--- a/src/components/search/filters/dynamic-range-filter/DynamicRangeFilter.unit.tsx
+++ b/src/components/search/filters/dynamic-range-filter/DynamicRangeFilter.unit.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import {DynamicRangeFilter} from "./DynamicRangeFilter";
-import {SearchkitManager} from "../../../../core";
+import {SearchkitManager, DynamicRangeAccessor} from "../../../../core";
 import {
   fastClick, hasClass, jsxToHTML, printPrettyHtml
 } from "../../../__test__/TestHelpers"
@@ -38,7 +38,7 @@ describe("Dynamic Range Filter tests", () => {
       })
 
       this.wrapper.update()
-      this.accessor = this.searchkit.accessors.getAccessors()[0]
+      this.accessor = this.searchkit.getAccessorByType(DynamicRangeAccessor)
     }
 
   });

--- a/src/components/search/filters/facet-filter/FacetFilter.unit.tsx
+++ b/src/components/search/filters/facet-filter/FacetFilter.unit.tsx
@@ -3,7 +3,7 @@ import {mount, render} from "enzyme"
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml} from "../../../__test__/TestHelpers"
 import {FacetFilter} from "./FacetFilter"
 import {RefinementListFilter} from "./RefinementListFilter"
-import {SearchkitManager, Utils, FieldOptions} from "../../../../core"
+import {SearchkitManager, Utils, FieldOptions, FacetAccessor} from "../../../../core"
 import {Toggle, ItemComponent} from "../../../ui"
 
 import * as _ from "lodash"
@@ -30,7 +30,7 @@ describe("Facet Filter tests", () => {
       }
     })
 
-    this.accessor = this.searchkit.accessors.getAccessors()[0]
+    this.accessor = this.searchkit.getAccessorByType(FacetAccessor)
   }
 
   beforeEach(() => {

--- a/src/components/search/filters/facet-filter/MenuFilter.unit.tsx
+++ b/src/components/search/filters/facet-filter/MenuFilter.unit.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from "react-dom";
 import {mount, render} from "enzyme";
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml} from "../../../__test__/TestHelpers"
 import {MenuFilter} from "./MenuFilter";
-import {SearchkitManager, Utils, ArrayState} from "../../../../core";
+import {SearchkitManager, Utils, ArrayState, FacetAccessor} from "../../../../core";
 import {Toggle, ItemComponent, ItemList} from "../../../ui";
 ;
 import * as _ from "lodash"
@@ -27,7 +27,7 @@ describe("MenuFilter", ()=> {
       return this.wrapper.find(".sk-item-list")
         .children().at(at)
     }
-    this.accessor = this.searchkit.accessors.accessors[0]
+    this.accessor = this.searchkit.getAccessorByType(FacetAccessor)
     this.searchkit.setResults({
       aggregations:{
         color1:{

--- a/src/components/search/filters/hierarchical-menu-filter/test/HierarchicalMenuFilterSpec.tsx
+++ b/src/components/search/filters/hierarchical-menu-filter/test/HierarchicalMenuFilterSpec.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {mount} from "enzyme";
 import {HierarchicalMenuFilter} from "../src/HierarchicalMenuFilter";
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml} from "../../../../__test__/TestHelpers"
-import {SearchkitManager} from "../../../../../core";
+import { SearchkitManager, HierarchicalFacetAccessor} from "../../../../../core";
 ;
 import * as sinon from "sinon";
 import * as _ from "lodash"
@@ -19,7 +19,7 @@ describe("HierarchicalMenuFilter tests", () => {
         fields={["lvl1", "lvl2"]}
       />
     )
-    this.accessor = this.searchkit.accessors.accessors[0]
+    this.accessor = this.searchkit.getAccessorByType(HierarchicalFacetAccessor)
     this.setResults = ()=> {
       this.searchkit.setResults({
         aggregations:{

--- a/src/components/search/filters/hierarchical-refinement-filter/test/HierarchicalRefinementFilterSpec.tsx
+++ b/src/components/search/filters/hierarchical-refinement-filter/test/HierarchicalRefinementFilterSpec.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {mount} from "enzyme";
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml} from "../../../../__test__/TestHelpers"
 import {HierarchicalRefinementFilter} from "../src/HierarchicalRefinementFilter"
-import {SearchkitManager} from "../../../../../core"
+import {SearchkitManager, NestedFacetAccessor} from "../../../../../core"
 import * as _ from "lodash"
 import * as sinon from "sinon"
 
@@ -17,8 +17,7 @@ describe("Refinement List Filter tests", () => {
         field="test" id="testid" title="test title"
         searchkit={this.searchkit} />
     );
-    this.accessor = this.searchkit.accessors.getAccessors()[0]
-
+    this.accessor = this.searchkit.getAccessorByType(NestedFacetAccessor)
     this.setResults = ()=> {
       this.searchkit.setResults({
         aggregations: {

--- a/src/components/search/filters/input-filter/InputFilter.unit.tsx
+++ b/src/components/search/filters/input-filter/InputFilter.unit.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import { InputFilter } from "./InputFilter";
-import { SearchkitManager, SimpleQueryString, QueryString } from "../../../../core";
-;
+import { 
+  SearchkitManager, SimpleQueryString, QueryString, QueryAccessor
+} from "../../../../core";
+
 import {
   fastClick, hasClass, jsxToHTML, printPrettyHtml
 } from "../../../__test__/TestHelpers"
@@ -38,7 +40,7 @@ describe("InputFilter tests", () => {
                    prefixQueryFields={prefixQueryFields}
                    {...otherProps} />
       );
-      this.accessor = this.searchkit.accessors.getAccessors()[0]
+      this.accessor = this.searchkit.getAccessorByType(QueryAccessor)
     }
 
     this.setResults = ()=> {

--- a/src/components/search/filters/numeric-refinement-list-filter/test/NumericRefinementListFilterSpec.tsx
+++ b/src/components/search/filters/numeric-refinement-list-filter/test/NumericRefinementListFilterSpec.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {mount} from "enzyme";
 import {NumericRefinementListFilter} from "../src/NumericRefinementListFilter";
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml} from "../../../../__test__/TestHelpers"
-import {SearchkitManager, Utils} from "../../../../../core";
+import {SearchkitManager, Utils, NumericOptionsAccessor} from "../../../../../core";
 import {Select} from "../../../../ui";
 ;
 import * as sinon from "sinon";
@@ -22,7 +22,7 @@ describe("NumericRefinementListFilter tests", () => {
           {title:"21 to 40", from:21, to:41}
         ]}/>
       )
-      this.accessor = this.searchkit.accessors.accessors[0]
+      this.accessor = this.searchkit.getAccessorByType(NumericOptionsAccessor)
     }
     this.setResults = ()=> {
       this.searchkit.setResults({

--- a/src/components/search/filters/range-filter/test/RangeFilterSpec.tsx
+++ b/src/components/search/filters/range-filter/test/RangeFilterSpec.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import {RangeFilter} from "../src/RangeFilter";
-import {SearchkitManager} from "../../../../../core";
+import {SearchkitManager, RangeAccessor} from "../../../../../core";
 import {
   fastClick, hasClass, jsxToHTML, printPrettyHtml
 } from "../../../../__test__/TestHelpers"
@@ -52,7 +52,7 @@ describe("Range Filter tests", () => {
       })
 
       this.wrapper.update()
-      this.accessor = this.searchkit.accessors.getAccessors()[0]
+      this.accessor = this.searchkit.getAccessorByType(RangeAccessor)
     }
 
 

--- a/src/components/search/filters/tag-filter/TagFilter.unit.tsx
+++ b/src/components/search/filters/tag-filter/TagFilter.unit.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import {mount, render} from "enzyme";
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml, htmlClean} from "../../../__test__/TestHelpers"
 import { TagFilter, TagFilterConfig } from "./";
-import {SearchkitManager, Utils} from "../../../../core";
+import {SearchkitManager, Utils, FacetAccessor} from "../../../../core";
 
 ;
 import * as _ from "lodash"
@@ -29,7 +29,7 @@ describe("TagFilter tests", () => {
       }
     })
 
-    this.accessor = this.searchkit.accessors.getAccessors()[0]
+    this.accessor = this.searchkit.getAccessorByType(FacetAccessor)
   }
 
   beforeEach(() => {

--- a/src/components/search/filters/tag-filter/TagFilterList.unit.tsx
+++ b/src/components/search/filters/tag-filter/TagFilterList.unit.tsx
@@ -2,7 +2,7 @@ import * as React from "react";;
 import {mount, render} from "enzyme";
 import {fastClick, hasClass, jsxToHTML, printPrettyHtml, htmlClean} from "../../../__test__/TestHelpers"
 import { TagFilterList, TagFilterConfig } from "./";
-import {SearchkitManager, Utils} from "../../../../core";
+import { SearchkitManager, Utils, FacetAccessor} from "../../../../core";
 
 ;
 import * as _ from "lodash"
@@ -29,7 +29,7 @@ describe("TagFilterList tests", () => {
       }
     })
 
-    this.accessor = this.searchkit.accessors.getAccessors()[0]
+    this.accessor = this.searchkit.getAccessorByType(FacetAccessor)
   }
 
   beforeEach(() => {

--- a/src/components/search/hits/src/Hits.tsx
+++ b/src/components/search/hits/src/Hits.tsx
@@ -84,7 +84,7 @@ export class HitsList extends React.Component<HitsListProps, any>{
 }
 
 export interface HitsProps extends SearchkitComponentProps{
-	hitsPerPage: number
+	hitsPerPage?: number
 	highlightFields?:Array<string>
 	customHighlight?:any
 	sourceFilter?:SourceFilterType
@@ -98,7 +98,7 @@ export class Hits extends SearchkitComponent<HitsProps, any> {
 	hitsAccessor:HitsAccessor
 
 	static propTypes = defaults({
-		hitsPerPage:PropTypes.number.isRequired,
+		hitsPerPage:PropTypes.number,
 		highlightFields:PropTypes.arrayOf(
 			PropTypes.string
 		),
@@ -118,6 +118,10 @@ export class Hits extends SearchkitComponent<HitsProps, any> {
 
 	componentWillMount() {
 		super.componentWillMount()
+		if(this.props.hitsPerPage){
+			this.searchkit.getAccessorByType(PageSizeAccessor)
+				.defaultSize = this.props.hitsPerPage
+		}
 		if(this.props.highlightFields) {
 			this.searchkit.addAccessor(
 				new HighlightAccessor(this.props.highlightFields))
@@ -134,9 +138,6 @@ export class Hits extends SearchkitComponent<HitsProps, any> {
 		this.searchkit.addAccessor(this.hitsAccessor)
 	}
 
-	defineAccessor(){
-		return new PageSizeAccessor(this.props.hitsPerPage)
-	}
 
 	render() {
 		let hits:Array<Object> = this.getHits()

--- a/src/components/search/hits/test/HitsSpec.tsx
+++ b/src/components/search/hits/test/HitsSpec.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import {Hits} from "../src/Hits";
-import {SearchkitManager} from "../../../../core";
+import {
+  SearchkitManager, PageSizeAccessor, HighlightAccessor, 
+  CustomHighlightAccessor, SourceFilterAccessor
+} from "../../../../core";
 import {
   fastClick, hasClass, jsxToHTML, printPrettyHtml
 } from "../../../__test__/TestHelpers"
@@ -24,10 +27,10 @@ describe("Hits component", () => {
               sourceFilter={["title"]}/>
       )
 
-      this.pageSizeAccessor = this.searchkit.accessors.accessors[0]
-      this.highlightAccessor = this.searchkit.accessors.accessors[1]
-      this.customHighlightAccessor = this.searchkit.accessors.accessors[2]
-      this.sourceFilterAccessor = this.searchkit.accessors.accessors[3]
+      this.pageSizeAccessor = this.searchkit.getAccessorByType(PageSizeAccessor)
+      this.highlightAccessor = this.searchkit.getAccessorByType(HighlightAccessor)
+      this.customHighlightAccessor = this.searchkit.getAccessorByType(CustomHighlightAccessor)
+      this.sourceFilterAccessor = this.searchkit.getAccessorByType(SourceFilterAccessor)
 
       this.hasRendered = () => {
         return this.wrapper.find(".sk-hits").length == 1

--- a/src/components/search/search-box/Searchbox.unit.tsx
+++ b/src/components/search/search-box/Searchbox.unit.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import {SearchBox} from "./SearchBox";
-import {SearchkitManager, QueryString } from "../../../core";
+import {SearchkitManager, QueryString, QueryAccessor } from "../../../core";
 ;
 import {
   fastClick, hasClass, jsxToHTML, printPrettyHtml
@@ -35,7 +35,7 @@ describe("Searchbox tests", () => {
           {...options}
         />
       );
-      this.accessor = this.searchkit.accessors.getAccessors()[0]
+      this.accessor = this.searchkit.getAccessorByType(QueryAccessor)
     }
 
     this.typeSearch = (value)=> {

--- a/src/components/search/sorting-selector/test/SortSelectorSpec.tsx
+++ b/src/components/search/sorting-selector/test/SortSelectorSpec.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {mount} from "enzyme";
 import {SortingSelector} from "../src/SortingSelector";
-import {SearchkitManager } from "../../../../core";
+import {SearchkitManager, SortingAccessor } from "../../../../core";
 import {Toggle} from "../../../ui";
 ;
 import * as sinon from "sinon";
@@ -25,7 +25,7 @@ describe("SortingSelector tests", () => {
       )
     }
     this.setWrapper()
-    this.accessor = this.searchkit.accessors.accessors[0]
+    this.accessor = this.searchkit.getAccessorByType(SortingAccessor)
     this.setResults = ()=> {
       this.searchkit.setResults({
         hits:{

--- a/src/core/AccessorManager.ts
+++ b/src/core/AccessorManager.ts
@@ -12,7 +12,7 @@ import {find} from "lodash"
 type StatefulAccessors = Array<StatefulAccessor<any>>
 
 export class AccessorManager {
-
+  
   accessors:Array<Accessor>
   statefulAccessors:{}
   queryAccessor:BaseQueryAccessor

--- a/test/e2e/server/apps/movie-app/index.tsx
+++ b/test/e2e/server/apps/movie-app/index.tsx
@@ -4,7 +4,7 @@ const {
   HierarchicalMenuFilter, HitsStats, SortingSelector, NoHits,
   SelectedFilters, ResetFilters, RangeFilter, NumericRefinementListFilter,
   ViewSwitcherHits, ViewSwitcherToggle, DynamicRangeFilter,MenuFilter ,
-  InputFilter, GroupedSelectedFilters, FastClick, FastClickComponent
+  InputFilter, GroupedSelectedFilters, FastClick, FastClickComponent, PageSizeSelector
 } = require("../../../../../src")
 
 FastClick.component = FastClickComponent
@@ -17,6 +17,10 @@ const host = "http://demo.searchkit.co/api/movies"
 import * as ReactDOM from "react-dom";
 import * as React from "react";
 const searchkit = new SearchkitManager(host)
+
+searchkit.shouldPeformSearch = (query) => {
+  return !!query.getQueryString()
+}
 
 import * as _ from "lodash"
 
@@ -93,11 +97,12 @@ class App extends React.Component<any, any> {
                   "hitstats.results_found":"{hitCount} results found"
                 }}/>
                 <ViewSwitcherToggle/>
+                <PageSizeSelector options={[10, 20, 30]} />
                 <SortingSelector options={[
                   {label:"Relevance", field:"_score", order:"desc"},
                   {label:"Latest Releases", field:"released", order:"desc"},
                   {label:"Earliest Releases", field:"released", order:"asc"}
-                ]}/>
+                ]}/>                
               </ActionBarRow>
 
               <ActionBarRow>
@@ -107,7 +112,7 @@ class App extends React.Component<any, any> {
 
             </ActionBar>
             <ViewSwitcherHits
-                hitsPerPage={12} highlightFields={["title","plot"]}
+                highlightFields={["title","plot"]}
                 sourceFilter={["plot", "title", "poster", "imdbId", "imdbRating", "year"]}
                 hitComponents = {[
                   {key:"grid", title:"Grid", itemComponent:MovieHitsGridItem, defaultOption:true},


### PR DESCRIPTION
- shouldPerformSearch can be overriden to control if searchkit runs searches
- Searchkit now defaults size, so doesn't rely on hitsPerPage in Hits component to work

#330 #537 