### PR TITLE
History + Guid fixes

### DIFF
--- a/packages/searchkit/package.json
+++ b/packages/searchkit/package.json
@@ -30,7 +30,7 @@
     "build:watch": "tsc -w",
     "prepublishOnly": "rm -rf lib; rm -rf release; npm run-script build;",
     "test": "jest -c jest.json",
-    "test:watch": "jest -c jest.json --watchAll",
+    "test:watch": "jest -c jest.json --watch",
     "test:coverage": "jest -c jest.json --coverage",
     "test:ci": "TEST_REPORT_FILENAME=unit-results.xml jest -c jest.json --coverage --testResultsProcessor=jest-junit-reporter --forceExit --ci -w 2"
   },

--- a/packages/searchkit/src/__test__/core/history/HistorySpec.ts
+++ b/packages/searchkit/src/__test__/core/history/HistorySpec.ts
@@ -1,12 +1,20 @@
-import { encodeObjUrl, decodeObjString } from '../../../core/history'
+import * as history from '../../../core/history'
 
 describe("History", () => {
 
   it("encode / decode searchkit obj", () => {
     const obj = {q: "test", categories: [["movie"],["Crime"]], actors: ["a", 'b-c', 'd & e', 'f=g'], writers: ['d'] }
-    const str = encodeObjUrl(obj)
+    const str = history.encodeObjUrl(obj)
     expect(str).toEqual('q=test&categories[0][0]=movie&categories[1][0]=Crime&actors[0]=a&actors[1]=b-c&actors[2]=d%20%26%20e&actors[3]=f%3Dg&writers[0]=d')
-    expect(decodeObjString(str)).toEqual(obj)
+    expect(history.decodeObjString(str)).toEqual(obj)
+  })
+
+  it("createHistoryInstance",  ()=> {    
+    //uses browser history by default
+    expect(history.createHistoryInstance().location.pathname).toEqual("/context.html")
+    spyOn(history, "supportsHistory").and.returnValue(false)
+    //uses memory history
+    expect(history.createHistoryInstance().location.pathname).toEqual("/")    
   })
 
 })

--- a/packages/searchkit/src/__test__/core/react/SearchkitProviderSpec.tsx
+++ b/packages/searchkit/src/__test__/core/react/SearchkitProviderSpec.tsx
@@ -36,9 +36,12 @@ describe("SearchkitProvider", ()=> {
     expect(this.searchkit.setupListeners).not.toHaveBeenCalled()
     this.wrapper.node.componentWillMount()
     expect(this.searchkit.setupListeners).toHaveBeenCalled()
+    this.searchkit.guidGenerator.counter = 10
     this.searchkit.unlistenHistory = jasmine.createSpy("unlisten")
     this.wrapper.node.componentWillUnmount()
     expect(this.searchkit.unlistenHistory).toHaveBeenCalled()
+    expect(this.searchkit.guidGenerator.counter).toEqual(0)
+
   })
 
 

--- a/packages/searchkit/src/core/history.ts
+++ b/packages/searchkit/src/core/history.ts
@@ -1,4 +1,4 @@
-import { createBrowserHistory, History } from 'history'
+import { createBrowserHistory, createMemoryHistory,  History } from 'history'
 const qs = require("qs")
 
 export const encodeObjUrl = (obj) => {
@@ -9,6 +9,10 @@ export const decodeObjString = (str) => {
   return qs.parse(str)
 }
 
+export const supportsHistory = ()=> {
+  return !!window.history
+}
+
 export const createHistoryInstance = function():History{
-  return createBrowserHistory()
+  return supportsHistory() ? createBrowserHistory() : createMemoryHistory()
 }

--- a/packages/searchkit/src/core/react/SearchkitProvider.tsx
+++ b/packages/searchkit/src/core/react/SearchkitProvider.tsx
@@ -27,7 +27,9 @@ export class SearchkitProvider extends React.Component<SearchkitProps,any> {
 	}
 
 	componentWillUnmount(){
-		this.props.searchkit.unlistenHistory()
+		const {searchkit} = this.props
+		searchkit.unlistenHistory()
+		searchkit.guidGenerator.reset()
 	}
 
 	getChildContext(){


### PR DESCRIPTION
- reset searchkit guidCounter on provider unmount, which allows searchkit state to be reconstructed with routers
- detect if history is supported and provide correct implementation, convenience for running on node.js