### PR TITLE
Force toString() conversion of bemBlock classes in order to prevent ReactJS from ignoring className attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ $CIRCLE_TEST_REPORTS
 _book
 coverage
 lib
+.idea

--- a/src/components/search/filters/input-filter/InputFilter.tsx
+++ b/src/components/search/filters/input-filter/InputFilter.tsx
@@ -176,13 +176,13 @@ export class InputFilter extends SearchkitComponent<InputFilterProps, any> {
   render() {
     const { containerComponent, title, id } = this.props
     const block = this.bemBlocks.container
-    const value = this.getValue()    
+    const value = this.getValue()
     return renderComponent(containerComponent, {
       title,
       className: id ? `filter--${id}` : undefined,
       disabled: (this.searchkit.getHitsCount() == 0) && (this.getAccessorValue() == "")
     },
-      <div className={block().state({focused:this.state.focused})}>
+      <div className={block().state({focused:this.state.focused}).toString()}>
         <form onSubmit={this.onSubmit.bind(this)}>
           <div className={block("icon")}></div>
           <input type="text"

--- a/src/components/search/search-box/SearchBox.tsx
+++ b/src/components/search/search-box/SearchBox.tsx
@@ -119,7 +119,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
       return input
     }
   }
-  
+
   getAccessorValue(){
     return (this.accessor.state.getValue() || "") + ""
   }
@@ -139,11 +139,11 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
     if (!focused){
       const { input } = this.state
       if (this.props.blurAction == "search"
-        && !isUndefined(input) 
+        && !isUndefined(input)
         && input != this.getAccessorValue()){
         this.searchQuery(input)
       }
-      this.setState({ 
+      this.setState({
         focused,
         input: undefined // Flush (should use accessor's state now)
       })
@@ -156,7 +156,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
     let block = this.bemBlocks.container
 
     return (
-      <div className={block().state({focused:this.state.focused})}>
+      <div className={block().state({focused:this.state.focused}).toString()}>
         <form onSubmit={this.onSubmit.bind(this)}>
           <div className={block("icon")}></div>
           <input type="text"


### PR DESCRIPTION
ReactJS 16 [throws warning and ignores className](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#changes-in-detail) attribute in case if it is not a string.

In order to prevent it the Bem-cn library [suggests](https://github.com/albburtsev/bem-cn#2) to force **toString()** conversion of bemBlock classes.

This merge request forces SearchBox and InputFilter related classes to be converted to string explicitly.