### PR TITLE
Replace deprecated _all in SuggestionsAccessor

### DIFF
--- a/packages/searchkit/src/core/accessors/SuggestionsAccessor.ts
+++ b/packages/searchkit/src/core/accessors/SuggestionsAccessor.ts
@@ -23,7 +23,7 @@ export class SuggestionsAccessor extends Accessor {
             max_errors : 1,
             gram_size : 4,
             direct_generator : [{
-              field : "_all",
+              field :this.field,
               suggest_mode : "always",
               min_word_length : 1
             }]


### PR DESCRIPTION
`_all` field is deprecated in ES 6.0.0. See https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-all-field.html

As such, `direct_generator`, referenced in `SuggestionsAccessor`, is no longer operational. This PR  adresses this, by using directly the current field instead. Since there is no longer a standard catchall field, keeping the generation on a catchall field was not possible.