### PR TITLE
window is undefined on server side, fixed invalid logic in SSR support

### DIFF
--- a/packages/searchkit/src/core/SearchkitManager.ts
+++ b/packages/searchkit/src/core/SearchkitManager.ts
@@ -76,7 +76,7 @@ export class SearchkitManager {
       searchOnLoad:true,
       defaultSize:20,
       createHistory:createHistoryInstance,
-      getLocation:()=> window.location
+      getLocation:()=> typeof window !== 'undefined' && window.location
     })
     this.host = host
     this.guidGenerator = new GuidGenerator()

--- a/packages/searchkit/src/core/history.ts
+++ b/packages/searchkit/src/core/history.ts
@@ -10,7 +10,7 @@ export const decodeObjString = (str) => {
 }
 
 export const supportsHistory = ()=> {
-  return !!window.history
+  return typeof window !== 'undefined' && !!window.history
 }
 
 export const createHistoryInstance = function():History{


### PR DESCRIPTION
```
window is not defined
ReferenceError: window is not defined
    at Object.exports.supportsHistory (/node_modules/searchkit/src/core/history.ts:13:12)
```