### PR TITLE
Add 2.3.0 to changelog.md & mention the breaking change in FacetFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 2.3.0 (28th November, 2017)
+
+- Breaking change in FacetFilter in commit: [d7f9eab70bc9b87f91f2122ecf1667a13f1b6a0e](https://github.com/searchkit/searchkit/commit/d7f9eab70bc9b87f91f2122ecf1667a13f1b6a0e)
+  ```
+    Non String agg type fix (#536)
+
+    * make FacetAccessor namespaced by id like all others
+
+    * Fix numeric/boolean values for aggs
+
+    - cast bucket keys to strings
+    - fix FacetFilter use of field as key(breaking change)
+    - Accessor throws better error when using same id on imcompatible component
+    - fix e2e apps
+
+    * gen bundle
+
+    * add id change to TagFilter docs
+    ```
+    the key used was changed from `filter` to `id` here: https://github.com/searchkit/searchkit/commit/d7f9eab70bc9b87f91f2122ecf1667a13f1b6a0e#diff-f172a23508b6de00b38c007df825d91a
+
 # 2.2.0 (20th August, 2017)
 - Passing credentials in the request (#481)
 


### PR DESCRIPTION
We upgraded from 2.1.0 to 2.3.0 and it took us a while to understand why the requests sent from searchkit to our backend look like this:

```json
{
 "post_filter": {
  "term": {
   "undefined": "brands"
  }
 },
 "aggs": {
  "_type3": {
   "filter": {
    "term": {
     "undefined": "brands"
    }
   },
   "aggs": {
    "undefined": {
     "terms": {}
    },
    "undefined_count": {
     "cardinality": {}
    }
   }
  }
 }
}
```

I had to check the commits one by one, from 2.1.0 to get the to this change: https://github.com/searchkit/searchkit/commit/d7f9eab70bc9b87f91f2122ecf1667a13f1b6a0e#diff-f172a23508b6de00b38c007df825d91a

So I think it might save someone else's time to mention the breaking change in the change log file

thanks :) 