### PR TITLE
Include: arrayLimit option argument in qs.parse() call

### DIFF
--- a/packages/searchkit/src/core/history.ts
+++ b/packages/searchkit/src/core/history.ts
@@ -6,7 +6,7 @@ export const encodeObjUrl = (obj) => {
 }
 
 export const decodeObjString = (str) => {
-  return qs.parse(str)
+  return qs.parse(str, { arrayLimit: 1000 })
 }
 
 export const supportsHistory = ()=> {


### PR DESCRIPTION
Our project is using Searchkit and our current implementation handles responses to `this.accessor.state.getValue()` by treating the return value as an array of strings.

However, because the `qs.parse()` function has an [arrayLimit value of 20](https://github.com/ljharb/qs/blob/master/lib/parse.js#L10), when 22 or more items are in the query params (acquired in [`SearchkitManager.prototype.searchFromUrlQuery`](https://github.com/searchkit/searchkit/blob/develop/packages/searchkit/src/core/SearchkitManager.ts#L174-L178)) then the response format is altered, e.g.:

`21 items: ["China", "Taiwan", "India", … ]`
`22 items: { 0: "China", 1: "Taiwan", 2: "India", … }`

Rather than have to accommodate both response formats for every call to `this.accessor.state.getValue()`, this PR increases the arrayLimit to 1000 (i.e. a higher amount of query params you would ordinarily expect to see) so that responses are consistent in their format.