### PR TITLE
Log the Error object instead of its stack

### DIFF
--- a/packages/searchkit/src/core/SearchkitManager.ts
+++ b/packages/searchkit/src/core/SearchkitManager.ts
@@ -158,7 +158,7 @@ export class SearchkitManager {
     this.registrationCompleted.then(()=> {
       this.searchFromUrlQuery(location.search)
     }).catch((e)=> {
-      console.error(e.stack)
+      console.error(e)
     })
   }
 


### PR DESCRIPTION
Fixes #658

`Error.stack` is not standard and do not include the error message in other browsers than Chrome, which makes it difficult to investigate a bug.
Switching to logging the fill error object should be fine in every browser.