### PR TITLE
fix warning "You provided a `value` prop to a form field without an `onChange` handler"

### DIFF
--- a/packages/searchkit/src/components/search/search-box/SearchBox.tsx
+++ b/packages/searchkit/src/components/search/search-box/SearchBox.tsx
@@ -170,7 +170,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
           onBlur={this.setFocusState.bind(this, false)}
           ref="queryField"
           autoFocus={this.props.autofocus}
-          onInput={this.onChange.bind(this)}/>
+          onChange={this.onChange.bind(this)}/>
           <input type="submit" value={this.translate("searchbox.button")} className={block("action")} data-qa="submit"/>
           <div data-qa="loader" className={block("loader").mix("sk-spinning-loader").state({hidden:!this.isLoading()})}></div>
         </form>

--- a/packages/searchkit/src/components/search/search-box/Searchbox.unit.tsx
+++ b/packages/searchkit/src/components/search/search-box/Searchbox.unit.tsx
@@ -39,7 +39,7 @@ describe("Searchbox tests", () => {
 
     this.typeSearch = (value)=> {
       this.wrapper.find(".sk-search-box__text")
-        .simulate("input", {target:{value}})
+        .simulate("change", {target:{value}})
     }
 
   });


### PR DESCRIPTION
```
Warning: Failed prop type: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
    in input (created by SearchBox)
    in form (created by SearchBox)
    in div (created by SearchBox)
    in SearchBox (created by App)
    in div
    in Unknown (created by App)
    in SearchkitProvider (created by App)
    in App
```


I didnt find official documentation, but this old merged pr https://github.com/facebook/react/pull/4003
says 

```
For <input> and <textarea>, onChange supersedes — and should generally be used instead of — the DOM's built-in oninput event handler.
```

![2018-11-29-11 52 17-screenshot](https://user-images.githubusercontent.com/7573215/49214010-59310f00-f3ce-11e8-8b22-d21e7fd52939.png)


React version

    "react": "^16.6.3",
    "react-dom": "^16.6.3",
