### PR TITLE
Updated searchkit to work with React 16.4

### DIFF
--- a/packages/searchkit/src/__test__/core/react/SearchkitComponentSpec.tsx
+++ b/packages/searchkit/src/__test__/core/react/SearchkitComponentSpec.tsx
@@ -72,14 +72,14 @@ describe("SearchkitComponent", ()=> {
       .toBe("searchkit_via_props")
   })
 
-  it("componentWillMount()", ()=> {
+  it("componentDidMount()", ()=> {
     spyOn(this.component, "forceUpdate")
     let searchkit = SearchkitManager.mock()
     searchkit.accessors = new AccessorManager()
     let accessor = new Accessor()
     this.component.defineAccessor = ()=> accessor
     spyOn(console, "warn")
-    this.component.componentWillMount()
+    this.component.componentDidMount()
     expect(this.component.searchkit).toBe(undefined)
     expect(this.component.accessor).toBe(undefined)
     expect(console.warn).toHaveBeenCalledWith(
@@ -87,14 +87,14 @@ describe("SearchkitComponent", ()=> {
     )
 
     this.component.props = {searchkit}
-    this.component.componentWillMount()
+    this.component.componentDidMount()
     expect(this.component.searchkit).toBe(searchkit)
     expect(this.component.accessor).toBe(accessor)
     expect(searchkit.accessors.accessors)
       .toEqual([accessor])
-    expect(this.component.forceUpdate).not.toHaveBeenCalled()
+    expect(this.component.forceUpdate).toHaveBeenCalledTimes(2)
     searchkit.emitter.trigger()
-    expect(this.component.forceUpdate).toHaveBeenCalled()
+    expect(this.component.forceUpdate).toHaveBeenCalledTimes(3)
 
     expect(searchkit.emitter.listeners.length).toBe(1)
     this.component.componentWillUnmount()

--- a/packages/searchkit/src/__test__/core/react/SearchkitProviderSpec.tsx
+++ b/packages/searchkit/src/__test__/core/react/SearchkitProviderSpec.tsx
@@ -34,7 +34,7 @@ describe("SearchkitProvider", ()=> {
   it("should call setupListeners()", ()=> {
     spyOn(this.searchkit, "setupListeners")
     expect(this.searchkit.setupListeners).not.toHaveBeenCalled()
-    this.wrapper.instance().componentWillMount()
+    this.wrapper.instance().componentDidMount()
     expect(this.searchkit.setupListeners).toHaveBeenCalled()
     this.searchkit.guidGenerator.counter = 10
     this.searchkit.unlistenHistory = jasmine.createSpy("unlisten")

--- a/packages/searchkit/src/components/display/view-switcher/ViewSwitcherHits.tsx
+++ b/packages/searchkit/src/components/display/view-switcher/ViewSwitcherHits.tsx
@@ -42,6 +42,7 @@ export class ViewSwitcherHits extends SearchkitComponent<ViewSwitcherHitsProps, 
     return new ViewOptionsAccessor("view", this.props.hitComponents)
   }
   render(){
+		if (!this.accessor) return null;
     const selectedOption = this.accessor.getSelectedOption()
     const props = {
       ...this.props,

--- a/packages/searchkit/src/components/search/filters/checkbox-filter/CheckboxFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/checkbox-filter/CheckboxFilter.tsx
@@ -76,6 +76,7 @@ export class CheckboxFilter extends SearchkitComponent<CheckboxFilterProps, any>
   }
 
   render(): React.ReactElement<any> {
+    if(!this.accessor) return null;
     const { listComponent, containerComponent, showCount, title, id, label } = this.props
 
     const disabled =  (this.searchkit.getHitsCount() == 0) && !this.accessor.state.getValue()

--- a/packages/searchkit/src/components/search/filters/dynamic-range-filter/DynamicRangeFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/dynamic-range-filter/DynamicRangeFilter.tsx
@@ -100,6 +100,7 @@ export class DynamicRangeFilter extends SearchkitComponent<DynamicRangeFilterPro
 	}
 
 	render(): React.ReactElement<any> {
+    if (!this.accessor) return null;
     const { id, title, containerComponent } = this.props
 
     return renderComponent(containerComponent, {

--- a/packages/searchkit/src/components/search/filters/facet-filter/FacetFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/facet-filter/FacetFilter.tsx
@@ -91,6 +91,7 @@ export class FacetFilter extends SearchkitComponent<FacetFilterProps, any> {
   }
 
   render() {
+    if (!this.accessor) return null;
     const { listComponent, containerComponent, showCount, title, id, countFormatter } = this.props
     return renderComponent(containerComponent, {
       title,

--- a/packages/searchkit/src/components/search/filters/hierarchical-menu-filter/src/HierarchicalMenuFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/hierarchical-menu-filter/src/HierarchicalMenuFilter.tsx
@@ -109,6 +109,7 @@ export class HierarchicalMenuFilter extends SearchkitComponent<HierarchicalMenuF
 	}
 
 	render() {
+		if(!this.accessor) return null;
 		const block = this.bemBlocks.container
 		const { id, title, containerComponent } = this.props
 		return renderComponent(

--- a/packages/searchkit/src/components/search/filters/hierarchical-refinement-filter/src/HierarchicalRefinementFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/hierarchical-refinement-filter/src/HierarchicalRefinementFilter.tsx
@@ -112,6 +112,7 @@ export class HierarchicalRefinementFilter extends SearchkitComponent<Hierarchica
 	}
 
 	render() {
+		if(!this.accessor) return null;
 		const block = this.bemBlocks.container
 		const { id, title, containerComponent } = this.props
 		return renderComponent(

--- a/packages/searchkit/src/components/search/filters/input-filter/InputFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/input-filter/InputFilter.tsx
@@ -86,8 +86,8 @@ export class InputFilter extends SearchkitComponent<InputFilterProps, any> {
     }, props.searchThrottleTime)
   }
 
-  componentWillMount() {
-    super.componentWillMount()
+  componentDidMount() {
+    super.componentDidMount()
   }
 
   defineBEMBlocks() {
@@ -176,6 +176,7 @@ export class InputFilter extends SearchkitComponent<InputFilterProps, any> {
   }
 
   render() {
+    if (!this.accessor) return null;
     const { containerComponent, title, id } = this.props
     const block = this.bemBlocks.container
     const value = this.getValue()

--- a/packages/searchkit/src/components/search/filters/numeric-refinement-list-filter/src/NumericRefinementListFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/numeric-refinement-list-filter/src/NumericRefinementListFilter.tsx
@@ -97,6 +97,7 @@ export class NumericRefinementListFilter extends SearchkitComponent<NumericRefin
   }
 
   render() : React.ReactElement<any> {
+    if (!this.accessor) return null;
     const {
 			listComponent, containerComponent, itemComponent,
 			showCount, title, id, mod, className, countFormatter

--- a/packages/searchkit/src/components/search/filters/range-filter/src/RangeFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/range-filter/src/RangeFilter.tsx
@@ -107,6 +107,7 @@ export class RangeFilter extends SearchkitComponent<RangeFilterProps, any> {
 	}
 
   render() : React.ReactElement<any> {
+    if(!this.accessor) return null;
     const { id, title, containerComponent } = this.props
 
     return renderComponent(containerComponent, {

--- a/packages/searchkit/src/components/search/filters/reset-filters/src/ResetFilters.tsx
+++ b/packages/searchkit/src/components/search/filters/reset-filters/src/ResetFilters.tsx
@@ -82,6 +82,7 @@ export class ResetFilters extends SearchkitComponent<ResetFiltersProps, any> {
 	}
 
   render() {
+	if(!this.accessor) return null;
 		const props:ResetFiltersDisplayProps = {
 			bemBlock:this.bemBlocks.container,
 			resetFilters:this.resetFilters,

--- a/packages/searchkit/src/components/search/hits/src/Hits.tsx
+++ b/packages/searchkit/src/components/search/hits/src/Hits.tsx
@@ -111,8 +111,8 @@ export class Hits extends SearchkitComponent<HitsProps, any> {
 		scrollTo: "body"
 	}
 
-	componentWillMount() {
-		super.componentWillMount()
+	componentDidMount() {
+		super.componentDidMount()
 		if(this.props.hitsPerPage){
 			this.searchkit.getAccessorByType(PageSizeAccessor)
 				.defaultSize = this.props.hitsPerPage

--- a/packages/searchkit/src/components/search/hits/src/NoHits.tsx
+++ b/packages/searchkit/src/components/search/hits/src/NoHits.tsx
@@ -49,8 +49,8 @@ export class NoHits extends SearchkitComponent<NoHitsProps, any> {
 		component: NoHitsDisplay
 	}
 
-	componentWillMount() {
-		super.componentWillMount()
+	componentDidMount() {
+		super.componentDidMount()
 		this.noFiltersAccessor = this.searchkit.addAccessor(
 			new NoFiltersHitCountAccessor()
 		)

--- a/packages/searchkit/src/components/search/pagination/src/Pagination.tsx
+++ b/packages/searchkit/src/components/search/pagination/src/Pagination.tsx
@@ -115,6 +115,7 @@ export class Pagination extends SearchkitComponent<PaginationProps, any> {
   }
 
   render() {
+    if (!this.accessor) return null;
     if (!this.hasHits()) return null;
     const className = block(this.props.mod).state({numbered:this.props.showNumbers})
 

--- a/packages/searchkit/src/components/search/search-box/SearchBox.tsx
+++ b/packages/searchkit/src/components/search/search-box/SearchBox.tsx
@@ -155,6 +155,7 @@ export class SearchBox extends SearchkitComponent<SearchBoxProps, any> {
   }
 
   render() {
+    if (!this.accessor) return null;
     let block = this.bemBlocks.container
 
     return (

--- a/packages/searchkit/src/components/search/sorting-selector/src/SortingSelector.tsx
+++ b/packages/searchkit/src/components/search/sorting-selector/src/SortingSelector.tsx
@@ -55,6 +55,7 @@ export class SortingSelector extends SearchkitComponent<SortingProps, any> {
 	}
 
   render(): React.ReactElement<any> {
+    if (!this.accessor) return null;
     const { listComponent } = this.props
 		const options = this.accessor.options.options
     const selected = [this.accessor.getSelectedOption().key]

--- a/packages/searchkit/src/core/react/SearchkitComponent.ts
+++ b/packages/searchkit/src/core/react/SearchkitComponent.ts
@@ -16,7 +16,7 @@ export interface SearchkitComponentProps {
 }
 
 export class SearchkitComponent<P extends SearchkitComponentProps,S> extends React.Component<P,S> {
-  searchkit:SearchkitManager
+  _searchkit:SearchkitManager
   accessor:Accessor
   stateListenerUnsubscribe:Function
   translations:Object = {}

--- a/packages/searchkit/src/core/react/SearchkitComponent.ts
+++ b/packages/searchkit/src/core/react/SearchkitComponent.ts
@@ -64,24 +64,45 @@ export class SearchkitComponent<P extends SearchkitComponentProps,S> extends Rea
       return block(cssClass).el
     })
   }
-  _getSearchkit(){
-    return this.props.searchkit || this.context["searchkit"]
+
+  get searchkit(): SearchkitManager {
+    return this._searchkit || (this._searchkit = this._getSearchkit());
   }
-  componentWillMount(){
-    this.searchkit = this._getSearchkit()
-    if(this.searchkit){
-      this.accessor  = this.defineAccessor()
-      if(this.accessor){
-        this.accessor = this.searchkit.addAccessor(this.accessor)
-      }
-      this.stateListenerUnsubscribe = this.searchkit.emitter.addListener(()=> {
-        if(!this.unmounted){
+
+  _getSearchkit(): SearchkitManager {
+    return this.props.searchkit || this.context["searchkit"];
+  }
+
+  set searchkit(value: SearchkitManager) {
+    this._searchkit = value;
+  }
+
+  componentDidMount() {
+    this._initAccessor();
+    if (this.searchkit) {
+      this.stateListenerUnsubscribe = this.searchkit.emitter.addListener(() => {
+        if (!this.unmounted) {
           this.forceUpdate();
         }
-      })
-    } else {
-      console.warn("No searchkit found in props or context for " + this.constructor["name"])
+      });
     }
+    this.forceUpdate();
+  }
+  
+  _initAccessor() {
+    if (this.searchkit && !this.accessor) {
+      this.accessor = this.defineAccessor();
+      if (this.accessor) {
+        this.accessor = this.searchkit.addAccessor(this.accessor);
+        return true;
+      }
+    }
+    if (!this.searchkit) {
+      console.warn(
+        "No searchkit found in props or context for " + this.constructor["name"]
+      );
+    }
+    return false;
   }
 
   componentWillUnmount(){

--- a/packages/searchkit/src/core/react/SearchkitProvider.tsx
+++ b/packages/searchkit/src/core/react/SearchkitProvider.tsx
@@ -18,11 +18,8 @@ export class SearchkitProvider extends React.Component<SearchkitProps,any> {
 		children:PropTypes.element.isRequired
 	}
 
-	componentWillMount() {
-		this.props.searchkit.setupListeners()
-	}
-
 	componentDidMount(){
+		this.props.searchkit.setupListeners()
 		this.props.searchkit.completeRegistration()
 	}
 


### PR DESCRIPTION
This PR should make Searchkit work with React 16.4+, however it does introduce breaking change in that the accessor is not guaranteed to be present on initial render. It's the only way to have accessor work since componentwillmount is not syncronous anymore, so you have to rely on renders.