### PR TITLE
query with true or false rather than 1 or 0 for boolean values

### DIFF
--- a/packages/searchkit/src/core/accessors/FacetAccessor.ts
+++ b/packages/searchkit/src/core/accessors/FacetAccessor.ts
@@ -78,7 +78,7 @@ export class FacetAccessor extends FilterBasedAccessor<ArrayState> {
     let rawBuckets:Array<any> = this.getRawBuckets()
     let keyIndex = {}
     each(rawBuckets, (item)=> {
-      item.key = String(item.key)
+      item.key = item.key_as_string || String(item.key);
       keyIndex[item.key] = item
     })
     let missingFilters = []


### PR DESCRIPTION
Prior to ES 6, boolean values could be queried with '0' or '1' instead of 'false' or 'true'. This PR will query with 'false' or 'true' for ES 6. It implements the solution proposed in the issue opened here: https://github.com/searchkit/searchkit/issues/655