### PR TITLE
don't pin lodash to avoid duplicates

### DIFF
--- a/packages/searchkit-autosuggest/package.json
+++ b/packages/searchkit-autosuggest/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@types/react-autosuggest": "^9.3.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.5",
     "react-autosuggest": "^9.3.2"
   }
 }

--- a/packages/searchkit-refinement-autosuggest/package.json
+++ b/packages/searchkit-refinement-autosuggest/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@types/react-select": "^1.0.59",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.5",
         "react-select": "^1.0.0-rc.10"
     }
 }

--- a/packages/searchkit/package.json
+++ b/packages/searchkit/package.json
@@ -55,7 +55,7 @@
     "axios": "^0.16.2",
     "history": "4.7.2",
     "immutability-helper": "^2.4.0",
-    "lodash": "4.17.5",
+    "lodash": "^4.17.5",
     "prop-types": "^15.5.8",
     "qs": "6.4.0",
     "rc-slider": "^8.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5572,14 +5572,12 @@ lodash.without@~4.4.0:
 lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-driver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
Don't pin lodash to remove duplicate lodash version and to be able to use only one updated version of lodash in my project instead of two.