### PR TITLE
fix warning "You provided a `value` prop to a form field without an `…

### DIFF
--- a/packages/searchkit/src/components/search/filters/input-filter/InputFilter.tsx
+++ b/packages/searchkit/src/components/search/filters/input-filter/InputFilter.tsx
@@ -197,7 +197,7 @@ export class InputFilter extends SearchkitComponent<InputFilterProps, any> {
             onBlur={this.setFocusState.bind(this, false)}
             ref="queryField"
             autoFocus={false}
-            onInput={this.onChange.bind(this)}/>
+            onChange={this.onChange.bind(this)}/>
           <input type="submit" value={this.translate("searchbox.button")} className={block("action")} data-qa="submit"/>
           <div data-qa="remove"
                onClick={this.onClear}

--- a/packages/searchkit/src/components/search/filters/input-filter/InputFilter.unit.tsx
+++ b/packages/searchkit/src/components/search/filters/input-filter/InputFilter.unit.tsx
@@ -63,7 +63,7 @@ describe("InputFilter tests", () => {
 
     this.typeSearch = (value)=> {
       this.wrapper.find(".sk-input-filter__text")
-        .simulate("input", {target:{value}})
+        .simulate("change", {target:{value}})
     }
 
   });


### PR DESCRIPTION
…onChange` handler" for InputFilter

Fixes the same issue as [PR 676](https://github.com/searchkit/searchkit/pull/676), but for InputFilter.