### PR TITLE
Remove unused imports

### DIFF
--- a/packages/searchkit-refinement-autosuggest/src/RefinementAutosuggestAccessor.ts
+++ b/packages/searchkit-refinement-autosuggest/src/RefinementAutosuggestAccessor.ts
@@ -1,7 +1,6 @@
 import {
     ImmutableQuery, FacetAccessor
 } from "searchkit"
-import map from "lodash/map"
 import get from "lodash/get"
 import { createRegexQuery } from "./Utils"
 

--- a/packages/searchkit-refinement-autosuggest/src/adapters/react-select/ReactSelectAdapter.tsx
+++ b/packages/searchkit-refinement-autosuggest/src/adapters/react-select/ReactSelectAdapter.tsx
@@ -1,9 +1,8 @@
 import * as React from "react"
-import { Async as SelectAsync, OptionValues, Option, Options } from 'react-select'
+import { Async as SelectAsync, Option, Options } from 'react-select'
 import 'react-select/dist/react-select.css';
 import compact from "lodash/compact"
 import flatten from "lodash/flatten"
-import property from "lodash/property"
 import map from "lodash/map"
 import {AdapterProps} from "../AdapterProps"
 


### PR DESCRIPTION
I was porting your **searchkit-autosuggest-package** and noticed that some of your import entries are not used: one of them definitely is moved to Utils.

So I decided to remove it from sources.