### PR TITLE
Update HitCount value | Pagination and SortingSelector not working | ElasticSearch 7

### DIFF
--- a/packages/searchkit/src/components/search/hits-stats/src/HitsStats.tsx
+++ b/packages/searchkit/src/components/search/hits-stats/src/HitsStats.tsx
@@ -72,7 +72,7 @@ export class HitsStats extends SearchkitComponent<HitsStatsProps, any> {
 			hitsCount: hitsCount,
 			resultsFoundLabel: this.translate("hitstats.results_found", {
 				timeTaken:timeTaken,
-				hitCount:hitsCount
+				hitCount:hitsCount.value
 			})
 		}
 		return renderComponent(this.props.component, props)


### PR DESCRIPTION
I got this bug : 

It was always displaying : 

![image](https://user-images.githubusercontent.com/16563634/57647934-8b24df00-75c4-11e9-90c0-bd137e310767.png)
        
I changed the hitCount key value for hitsCount.value 

And with this its correctly display like this :

![image](https://user-images.githubusercontent.com/16563634/57647898-747e8800-75c4-11e9-88d2-d1aaa98bc918.png)


**package.json**
"searchkit": "^2.3.1-alpha.9"