### PR TITLE
Make HitsList item key more unique

### DIFF
--- a/packages/searchkit/src/components/search/hits/src/Hits.tsx
+++ b/packages/searchkit/src/components/search/hits/src/Hits.tsx
@@ -70,7 +70,7 @@ export class HitsList extends React.PureComponent<HitsListProps, any>{
 			<div data-qa="hits" className={bemBlocks.container().mix(className)}>
 				{map(hits, (result: any, index)=> {
 					return renderComponent(itemComponent, {
-						key:result._id, result, bemBlocks, index
+						key: `${result._id}_${result._index}`, result, bemBlocks, index
 					})
 				})}
 			</div>


### PR DESCRIPTION
Prevent errors in case when `$all` `_index` has results with same `_id`

Closes #711