### PR TITLE
[FIX] encode and decodre url to be IETF compliant

### DIFF
--- a/packages/searchkit/src/__test__/core/history/HistorySpec.ts
+++ b/packages/searchkit/src/__test__/core/history/HistorySpec.ts
@@ -5,7 +5,7 @@ describe("History", () => {
   it("encode / decode searchkit obj", () => {
     const obj = {q: "test", categories: [["movie"],["Crime"]], actors: ["a", 'b-c', 'd & e', 'f=g'], writers: ['d'] }
     const str = history.encodeObjUrl(obj)
-    expect(str).toEqual('q=test&categories[0][0]=movie&categories[1][0]=Crime&actors[0]=a&actors[1]=b-c&actors[2]=d%20%26%20e&actors[3]=f%3Dg&writers[0]=d')
+    expect(str).toEqual('q=test&categories%255B0%255D%255B0%255D=movie&categories%255B1%255D%255B0%255D=Crime&actors%255B0%255D=a&actors%255B1%255D=b-c&actors%255B2%255D=d%2520%2526%2520e&actors%255B3%255D=f%253Dg&writers%255B0%255D=d')
     expect(history.decodeObjString(str)).toEqual(obj)
   })
 

--- a/packages/searchkit/src/core/history.ts
+++ b/packages/searchkit/src/core/history.ts
@@ -2,11 +2,11 @@ import { createBrowserHistory, createMemoryHistory,  History } from 'history'
 const qs = require("qs")
 
 export const encodeObjUrl = (obj) => {
-  return qs.stringify(obj, { encode: true, encodeValuesOnly: true })
+  return encodeURI(qs.stringify(obj, { encode: true, encodeValuesOnly: false }))
 }
 
 export const decodeObjString = (str) => {
-  return qs.parse(str)
+  return qs.parse(decodeURI(str))
 }
 
 export const supportsHistory = ()=> {


### PR DESCRIPTION
Makes the URLs generated by searchkit IETF compliant ([RFC3986](https://tools.ietf.org/html/rfc3986))
before:
`http://0.0.0.0:3333/search?price[min]=0&price[max]=52`
after:
`http://0.0.0.0:3333/search?price%255Bmin%255D=0&price%255Bmax%255D=52`