### PR TITLE
Use getHitsCount() in getTotalPages()

### DIFF
--- a/packages/searchkit/src/components/search/pagination/src/Pagination.tsx
+++ b/packages/searchkit/src/components/search/pagination/src/Pagination.tsx
@@ -70,9 +70,7 @@ export class Pagination extends SearchkitComponent<PaginationProps, any> {
   }
 
   getTotalPages(): number {
-    return Math.ceil(
-      get(this.getResults(), 'hits.total', 1) / get(this.getQuery(), 'query.size', 10)
-    )
+    return Math.ceil(this.getHitsCount() / get(this.getQuery(), 'query.size', 10))
   }
 
   isDisabled(pageNumber: number): boolean {


### PR DESCRIPTION
utilize getHitsCount() method in getTotalPages.

Fixes bug that prevented pages from being displayed when `showNumbers={true}` was enabled in the `Pagination` component. #732 