### PR TITLE
Update dead link to searchkit-boilerplate project

### DIFF
--- a/packages/searchkit-docs/docs/setup/project-setup.md
+++ b/packages/searchkit-docs/docs/setup/project-setup.md
@@ -2,10 +2,10 @@
 Our recommended project setup is using webpack and typescript. We also support using searchkit with ES6 / Webpack and using normal library script file. Installing via NPM is recommended.
 
 ## Using Module
-We recommend using webpack for module dependency management of Searchkit's src, css and static assets. requires scss, file loaders to properly resolve searchkit dependencies. See [searchkit boilerplate](http://github.com/searchkit/searchkit-boilerplate).
+We recommend using webpack for module dependency management of Searchkit's src, css and static assets. requires scss, file loaders to properly resolve searchkit dependencies. See [searchkit boilerplate](https://github.com/searchkit/component-boilerplate).
 
 ### Installing via NPM
-Searchkit is available on [npm](http://npmjs.com/package/searchkit). Searchkit is written with typescript therefore typescript definition files are available.
+Searchkit is available on [npm](https://npmjs.com/package/searchkit). Searchkit is written with typescript therefore typescript definition files are available.
 
 ```sh
   npm install searchkit --save


### PR DESCRIPTION
I'm just guessing what the correct link should be here. If this isn't it, it should probably just be removed.

Also, please use HTTPS links.