### PR TITLE
Allowed option deselection in NumericRefinementListFilter when using single select

### DIFF
--- a/packages/searchkit/src/__test__/core/accessors/NumericalOptionsAccessorSpec.ts
+++ b/packages/searchkit/src/__test__/core/accessors/NumericalOptionsAccessorSpec.ts
@@ -123,6 +123,14 @@ describe('NumericOptionsAccessor', () => {
       expect(this.searchkit.performSearch).toHaveBeenCalled()
       expect(this.accessor.state.getValue()).toEqual(['11_21'])
     })
+
+    it('should deselect already selected option - single select', () => {
+      this.options.multiselect = false
+      this.accessor.state = new ArrayState(['11_21'])
+      this.accessor.toggleOption('Affordable')
+      expect(this.searchkit.performSearch).toHaveBeenCalled()
+      expect(this.accessor.state.getValue()).toEqual([])
+    })
   })
 
   it('getRanges()', () => {

--- a/packages/searchkit/src/components/search/filters/numeric-refinement-list-filter/test/NumericRefinementListFilterSpec.tsx
+++ b/packages/searchkit/src/components/search/filters/numeric-refinement-list-filter/test/NumericRefinementListFilterSpec.tsx
@@ -93,8 +93,23 @@ describe('NumericRefinementListFilter tests', () => {
     this.accessor.options.multiselect = true
     fastClick(thirdOption)
     this.accessor.options.multiselect = false
+    fastClick(secondOption)
     fastClick(thirdOption)
     expect(this.accessor.state.getValue()).toEqual(['21_41'])
+  })
+
+  it('should deselect already selected option for single select', () => {
+    this.setWrapper()
+    this.setResults()
+    this.wrapper = this.wrapper.update()
+    const secondOption = this.getOptionAt(1)
+    this.accessor.options.multiselect = false
+    fastClick(secondOption)
+    expect(this.accessor.state.getValue()).toEqual(['0_21'])
+    expect(this.searchkit.performSearch).toHaveBeenCalled()
+    fastClick(secondOption)
+    expect(this.accessor.state.getValue()).toEqual([])
+    expect(this.searchkit.performSearch).toHaveBeenCalled()
   })
 
   it('should be disabled for empty buckets', () => {

--- a/packages/searchkit/src/core/accessors/NumericOptionsAccessor.ts
+++ b/packages/searchkit/src/core/accessors/NumericOptionsAccessor.ts
@@ -88,6 +88,8 @@ export class NumericOptionsAccessor extends FilterBasedAccessor<ArrayState> {
         this.state = this.state.clear()
       } else if (this.options.multiselect) {
         this.state = this.state.toggle(option.key)
+      } else if (includes(this.state.getValue(), option.key)) {
+        this.state = this.state.clear()
       } else {
         this.state = this.state.setValue([option.key])
       }


### PR DESCRIPTION
When we use `NumericRefinementListFilter` as single select. Then, it is not possible to deselect already selected option.
This pull request will allow deselection of already selected option.