### PR TITLE
Update api-setup.md

### DIFF
--- a/docs/docs/api-setup.md
+++ b/docs/docs/api-setup.md
@@ -93,6 +93,7 @@ const typeDefs = [
     }
 
     type HitFields {
+      root: String
     }
   `,
   SearchkitSchema


### PR DESCRIPTION
searchkit schema giving the error  
GraphQLError: Syntax Error: Expected Name, found }
due to the empty object of the type HitFields