### PR TITLE
Fix link to qbox.io

### DIFF
--- a/docs/docs/guides-indexing.md
+++ b/docs/docs/guides-indexing.md
@@ -6,7 +6,7 @@ slug: /guides/elasticsearch-setup-indexing
 ---
 
 ### Setup Elasticsearch
-Either pick a cloud offering for example [qbox.io](www.qbox.io?ref=searchkit) or run locally via [instructions here](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html)
+Either pick a cloud offering for example [qbox.io](https://www.qbox.io?ref=searchkit) or run locally via [instructions here](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html)
 
 ### Setup Fields + Mappings
 


### PR DESCRIPTION
This link was missing a protocol, making it a relative link to `https://searchkit.co/docs/guides/www.qbox.io?ref=searchkit` instead of  `www.qbox.io?ref=searchkit`.