### PR TITLE
feat: Add highlight support for matched words

### DIFF
--- a/packages/searchkit-cli/src/lib.ts
+++ b/packages/searchkit-cli/src/lib.ts
@@ -231,7 +231,7 @@ export const getSKQuickStartText = ({
   mapping
 }) => {
   const mappingCall = {
-      properties: mapping
+    properties: mapping
   }
 
   return `

--- a/packages/searchkit-schema/README.md
+++ b/packages/searchkit-schema/README.md
@@ -185,3 +185,77 @@ Will provide a GraphQL API where you can perform queries like:
 ```
 
 See [Schema Query Guide](https://searchkit.co/docs/guides/graphql-schema-queries-cheatsheet) for more examples.
+
+### Getting highlights for matches
+
+To receive ElasticSearch highlights for your matches you need to do the followings:
+
+1. Add `highlightedFields` under `hits` for your Searchkit config. Here you may list the name of fields for which you want to get highlights, or an object where you specify the field name and the highlight configuration according to the  [ElasticSearch highlighting](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html) documentation
+2. Add a `highlight` field to your `ResultHit` graphql schema type
+3. When configuring ApolloServer specify a custom resolver for `highlight`
+
+
+The following example generates a JSON encoded string version of the highlight objects received from ElasticSearch. You may specify another shape for `highlight` in your `ResultHit` type and a matching transformation of `hit.highlight` in your resolver.
+
+```js
+const searchkitConfig = {
+  host: 'http://localhost:9200/', // elasticsearch instance url
+  index: 'movies',
+  hits: {
+    fields: [ 'title', 'plot', 'poster' ],
+    highlightedFields: [
+      'title',
+      {
+        field: 'plot',
+        config: { 
+          pre_tags: ['<b>'], 
+          post_tags: ['</b>'] 
+        }
+      }
+    ]
+  },
+  query: new MultiMatchQuery({ 
+    fields: [ 'plot','title^4'] 
+  }),
+  facets: [
+    ...
+  ]
+}
+
+const { typeDefs, withSearchkitResolvers, context } = SearchkitSchema({
+  config: searchkitConfig,
+  typeName: 'ResultSet', 
+  hitTypeName: 'ResultHit',
+  addToQueryType: true 
+})
+
+const server = new ApolloServer({
+  typeDefs: [
+    gql`
+    type Query {
+      root: String
+    }
+
+    type HitFields {
+      title: String
+    }
+
+    type ResultHit implements SKHit {
+      id: ID!
+      fields: HitFields
+      highlight: String
+    }
+  `, ...typeDefs
+  ],
+  resolvers: withSearchkitResolvers({
+    ResultHit: {
+      highlight: (hit: any) => JSON.stringify(hit.highlight)
+    }
+  }),
+  introspection: true,
+  playground: true,
+  context: {
+    ...context
+  }
+})
+```

--- a/packages/searchkit-schema/src/core/SearchkitRequest.ts
+++ b/packages/searchkit-schema/src/core/SearchkitRequest.ts
@@ -107,6 +107,18 @@ export default class SearchkitRequest {
     const combinedFilterConfigs = [...(this.config.facets || []), ...(this.config.filters || [])]
     const postFilter = filterTransform(this.queryManager, combinedFilterConfigs)
 
+    let highlight
+    this.config.hits.highlightedFields?.forEach((field) => {
+      if (!highlight) {
+        highlight = { fields: {} }
+      }
+      if (typeof field == 'string') {
+        highlight.fields[field] = {}
+      } else {
+        highlight.fields[field.field] = field.config
+      }
+    })
+
     const baseQuery = { size: 0 }
 
     return mergeESQueries(
@@ -114,6 +126,7 @@ export default class SearchkitRequest {
         baseQuery,
         query && { query },
         postFilter && { post_filter: postFilter },
+        highlight && { highlight },
         ...(partialQueries as any[])
       ].filter(Boolean)
     )

--- a/packages/searchkit-schema/src/resolvers/HitsResolver.ts
+++ b/packages/searchkit-schema/src/resolvers/HitsResolver.ts
@@ -44,7 +44,9 @@ export default async (parent, parameters: HitsParameters, ctx) => {
       items: hits.hits.map((hit) => ({
         id: hit._id,
         fields: hit._source,
-        type: parent.searchkit.hitType
+        type: parent.searchkit.hitType,
+        highlight: hit.highlight,
+        rawHit: hit
       })),
       page: {
         total: hitsTotal,

--- a/packages/searchkit-schema/src/resolvers/ResultsResolver.ts
+++ b/packages/searchkit-schema/src/resolvers/ResultsResolver.ts
@@ -12,12 +12,18 @@ export interface SortingOption {
   defaultOption?: boolean
 }
 
+export interface CustomHighlightConfig {
+  field: string
+  config: any
+}
+
 export interface SearchkitConfig {
   host: string
   index: string
   sortOptions?: SortingOption[]
   hits: {
     fields: string[]
+    highlightedFields?: (string | CustomHighlightConfig)[]
   }
   query?: BaseQuery
   facets?: Array<BaseFacet>

--- a/packages/searchkit-schema/tests/__mock-data__/HitResolver/HighlightHits.json
+++ b/packages/searchkit-schema/tests/__mock-data__/HitResolver/HighlightHits.json
@@ -1,0 +1,420 @@
+{
+  "took" : 52,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 48,
+      "relation" : "eq"
+    },
+    "max_score" : 7.1922398,
+    "hits" : [
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0037638",
+        "_score" : 7.1922398,
+        "_source" : {
+          "type" : "movie",
+          "title" : "Detour",
+          "year" : 1945,
+          "rated" : "Approved",
+          "released" : "1945-11-07T00:00:00+01:00",
+          "genres" : [
+            "Crime",
+            "Drama",
+            "Film-Noir"
+          ],
+          "directors" : [
+            "Edgar G. Ulmer"
+          ],
+          "writers" : [
+            "Martin Goldsmith",
+            "Martin Goldsmith"
+          ],
+          "actors" : [
+            "Tom Neal",
+            "Ann Savage",
+            "Claudia Drake",
+            "Edmund MacDonald"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "Chance events trap hitch-hiker Al Roberts in a tightening net of film noir trouble.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTQxMzA0ODk4OV5BMl5BanBnXkFtZTcwOTkwMzQyMQ@@._V1_SX300.jpg",
+          "id" : "tt0037638",
+          "imdbrating" : 7.5
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0497116",
+        "_score" : 6.929497,
+        "_source" : {
+          "type" : "movie",
+          "title" : "An Inconvenient Truth",
+          "year" : 2006,
+          "rated" : "PG",
+          "released" : "2006-08-31T00:00:00+02:00",
+          "genres" : [
+            "Documentary"
+          ],
+          "directors" : [
+            "Davis Guggenheim"
+          ],
+          "writers" : [ ],
+          "actors" : [
+            "Al Gore",
+            "Billy West"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "A documentary on Al Gore's campaign to make the issue of global warming a recognized problem worldwide.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BOTg3NjYxMjM5OF5BMl5BanBnXkFtZTcwMzQzMDA0MQ@@._V1_SX300.jpg",
+          "id" : "tt0497116",
+          "metascore" : 75,
+          "imdbrating" : 7.6
+        },
+        "highlight" : {
+          "actors" : [
+            "<em>Al</em> Gore"
+          ]
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0391024",
+        "_score" : 6.805195,
+        "_source" : {
+          "type" : "movie",
+          "title" : "Control Room",
+          "year" : 2004,
+          "rated" : null,
+          "released" : "2004-06-18T00:00:00+02:00",
+          "genres" : [
+            "Documentary"
+          ],
+          "directors" : [
+            "Jehane Noujaim"
+          ],
+          "writers" : [
+            "Julia Bacha",
+            "Jehane Noujaim"
+          ],
+          "actors" : [
+            "Samir Khader",
+            "Josh Rushing",
+            "George W. Bush",
+            "Hassan Ibrahim"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "A documentary on perception of the United States's war with Iraq, with an emphasis on Al Jazeera's coverage.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMjA2NzM5NTkzOV5BMl5BanBnXkFtZTcwMjExMDcyMQ@@._V1_SX300.jpg",
+          "id" : "tt0391024",
+          "metascore" : 79,
+          "imdbrating" : 7.8
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0094226",
+        "_score" : 6.4576797,
+        "_source" : {
+          "type" : "movie",
+          "title" : "The Untouchables",
+          "year" : 1987,
+          "rated" : "R",
+          "released" : "1987-06-03T00:00:00+02:00",
+          "genres" : [
+            "Crime",
+            "Drama",
+            "History"
+          ],
+          "directors" : [
+            "Brian De Palma"
+          ],
+          "writers" : [
+            "Oscar Fraley",
+            "David Mamet"
+          ],
+          "actors" : [
+            "Kevin Costner",
+            "Sean Connery",
+            "Charles Martin Smith",
+            "Andy Garcia"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "Federal Agent Eliot Ness sets out to stop Al Capone; because of rampant corruption, he assembles a small, hand-picked team.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTc1MzY0MTcyMV5BMl5BanBnXkFtZTcwMzE3Njk3OA@@._V1_SX300.jpg",
+          "id" : "tt0094226",
+          "imdbrating" : 8
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0108734",
+        "_score" : 6.411784,
+        "_source" : {
+          "type" : "series",
+          "title" : "The Critic",
+          "year" : 1994,
+          "rated" : "TV-14",
+          "released" : "1994-01-26T00:00:00+01:00",
+          "genres" : [
+            "Animation",
+            "Comedy",
+            "Drama"
+          ],
+          "directors" : [ ],
+          "writers" : [
+            "Al Jean",
+            "Mike Reiss"
+          ],
+          "actors" : [
+            "Jon Lovitz",
+            "Nancy Cartwright",
+            "Christine Cavanaugh",
+            "Gerrit Graham"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "Jay Sherman is a New York film critic who has to review films he doesn't like for a living.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMjA3NDI2MzE3OV5BMl5BanBnXkFtZTcwNjA4NjQyMQ@@._V1_SX300.jpg",
+          "id" : "tt0108734",
+          "imdbrating" : 8.1
+        },
+        "highlight" : {
+          "writers" : [
+            "<b>Al</b> Jean"
+          ]
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0116913",
+        "_score" : 6.411784,
+        "_source" : {
+          "type" : "movie",
+          "title" : "Looking for Richard",
+          "year" : 1996,
+          "rated" : "PG-13",
+          "released" : "1996-10-11T00:00:00+02:00",
+          "genres" : [
+            "Documentary",
+            "Drama"
+          ],
+          "directors" : [
+            "Al Pacino"
+          ],
+          "writers" : [
+            "William Shakespeare",
+            "Al Pacino"
+          ],
+          "actors" : [
+            "Penelope Allen",
+            "Gordon MacDonald",
+            "Madison Arnold",
+            "Vincent Angell"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "Al Pacino's deeply-felt rumination on Shakespeare's significance and relevance to the modern world through interviews and an in-depth analysis of \"Richard III.\"",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTIyNTQwNzEwOV5BMl5BanBnXkFtZTcwMDEzNDMzMQ@@._V1_SX300.jpg",
+          "id" : "tt0116913",
+          "imdbrating" : 7.4
+        },
+        "highlight" : {
+          "writers" : [
+            "<b>Al</b> Pacino"
+          ]
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0098546",
+        "_score" : 5.8878617,
+        "_source" : {
+          "type" : "movie",
+          "title" : "UHF",
+          "year" : 1989,
+          "rated" : "PG-13",
+          "released" : "1989-07-21T00:00:00+02:00",
+          "genres" : [
+            "Comedy"
+          ],
+          "directors" : [
+            "Jay Levey"
+          ],
+          "writers" : [
+            "'Weird Al' Yankovic",
+            "Jay Levey"
+          ],
+          "actors" : [
+            "'Weird Al' Yankovic",
+            "Victoria Jackson",
+            "Kevin McCarthy",
+            "Michael Richards"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "A local public station gets a new owner. The station becomes a hit, with all sorts of hilarious sight gags and wacky humor.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTAzMjE2NDg5NjZeQTJeQWpwZ15BbWU3MDAzNzI4NzQ@._V1_SX300.jpg",
+          "id" : "tt0098546",
+          "metascore" : 32,
+          "imdbrating" : 7
+        },
+        "highlight" : {
+          "actors" : [
+            "'Weird <em>Al</em>' Yankovic"
+          ],
+          "writers" : [
+            "'Weird <b>Al</b>' Yankovic"
+          ]
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0097372",
+        "_score" : 5.5183444,
+        "_source" : {
+          "type" : "movie",
+          "title" : "For All Mankind",
+          "year" : 1989,
+          "rated" : "Not Rated",
+          "released" : "1989-11-01T00:00:00+01:00",
+          "genres" : [
+            "Documentary",
+            "History"
+          ],
+          "directors" : [
+            "Al Reinert"
+          ],
+          "writers" : [ ],
+          "actors" : [
+            "Jim Lovell",
+            "Russell Schweickart",
+            "Eugene Cernan",
+            "Michael Collins"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "This movie documents the Apollo missions perhaps the most definitively of any movie under two hours. Al Reinert watched all the footage shot during the missions--over 6,000,000 feet of it, ...",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BODE1MDIyNDUyM15BMl5BanBnXkFtZTcwNTc0MTk1Mg@@._V1_SX300.jpg",
+          "id" : "tt0097372",
+          "imdbrating" : 8.2
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0017925",
+        "_score" : 5.4430923,
+        "_source" : {
+          "type" : "movie",
+          "title" : "The General",
+          "year" : 1926,
+          "rated" : "Unrated",
+          "released" : "1927-02-24T00:00:00+01:00",
+          "genres" : [
+            "Action",
+            "Adventure",
+            "Comedy"
+          ],
+          "directors" : [
+            "Clyde Bruckman",
+            "Buster Keaton"
+          ],
+          "writers" : [
+            "Buster Keaton",
+            "Clyde Bruckman",
+            "Al Boasberg"
+          ],
+          "actors" : [
+            "Buster Keaton",
+            "Marion Mack",
+            "Glen Cavender",
+            "Jim Farley"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "When Union spies steal an engineer's beloved locomotive, he pursues it single handedly and straight through enemy lines.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BODQxMzMyNTY5Nl5BMl5BanBnXkFtZTcwMDMyNTk3OA@@._V1_SX300.jpg",
+          "id" : "tt0017925",
+          "imdbrating" : 8.3
+        },
+        "highlight" : {
+          "writers" : [
+            "<b>Al</b> Boasberg"
+          ]
+        }
+      },
+      {
+        "_index" : "imdb_movies",
+        "_type" : "_doc",
+        "_id" : "tt0068315",
+        "_score" : 5.4430923,
+        "_source" : {
+          "type" : "movie",
+          "title" : "Brian's Song",
+          "year" : 1971,
+          "rated" : "G",
+          "released" : "1971-11-30T00:00:00+01:00",
+          "genres" : [
+            "Biography",
+            "Drama",
+            "Sport"
+          ],
+          "directors" : [
+            "Buzz Kulik"
+          ],
+          "writers" : [
+            "Gale Sayers",
+            "Al Silverman",
+            "William Blinn"
+          ],
+          "actors" : [
+            "James Caan",
+            "Billy Dee Williams",
+            "Jack Warden",
+            "Bernie Casey"
+          ],
+          "countries" : [
+            "USA"
+          ],
+          "plot" : "Based on the real-life relationship between teammates Brian Piccolo and Gale Sayers and the bond established when Piccolo discovers that he is dying.",
+          "poster" : "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTkyNjQ3NTQ5Nl5BMl5BanBnXkFtZTcwMzk3NzUyMQ@@._V1_SX300.jpg",
+          "id" : "tt0068315",
+          "imdbrating" : 7.6
+        },
+        "highlight" : {
+          "writers" : [
+            "<b>Al</b> Silverman"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/packages/searchkit-schema/tests/__snapshots__/HitsResolver.test.ts.snap
+++ b/packages/searchkit-schema/tests/__snapshots__/HitsResolver.test.ts.snap
@@ -675,3 +675,169 @@ Object {
   },
 }
 `;
+
+exports[`Hits Resolver should return as expected should return correct highlight Results 2`] = `
+Object {
+  "results": Object {
+    "hits": Object {
+      "items": Array [
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Tom Neal",
+              "Ann Savage",
+              "Claudia Drake",
+              "Edmund MacDonald",
+            ],
+            "writers": Array [
+              "Martin Goldsmith",
+              "Martin Goldsmith",
+            ],
+          },
+          "highlight": null,
+          "id": "tt0037638",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Al Gore",
+              "Billy West",
+            ],
+            "writers": Array [],
+          },
+          "highlight": "{\\"actors\\":[\\"<em>Al</em> Gore\\"]}",
+          "id": "tt0497116",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Samir Khader",
+              "Josh Rushing",
+              "George W. Bush",
+              "Hassan Ibrahim",
+            ],
+            "writers": Array [
+              "Julia Bacha",
+              "Jehane Noujaim",
+            ],
+          },
+          "highlight": null,
+          "id": "tt0391024",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Kevin Costner",
+              "Sean Connery",
+              "Charles Martin Smith",
+              "Andy Garcia",
+            ],
+            "writers": Array [
+              "Oscar Fraley",
+              "David Mamet",
+            ],
+          },
+          "highlight": null,
+          "id": "tt0094226",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Jon Lovitz",
+              "Nancy Cartwright",
+              "Christine Cavanaugh",
+              "Gerrit Graham",
+            ],
+            "writers": Array [
+              "Al Jean",
+              "Mike Reiss",
+            ],
+          },
+          "highlight": "{\\"writers\\":[\\"<b>Al</b> Jean\\"]}",
+          "id": "tt0108734",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Penelope Allen",
+              "Gordon MacDonald",
+              "Madison Arnold",
+              "Vincent Angell",
+            ],
+            "writers": Array [
+              "William Shakespeare",
+              "Al Pacino",
+            ],
+          },
+          "highlight": "{\\"writers\\":[\\"<b>Al</b> Pacino\\"]}",
+          "id": "tt0116913",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "'Weird Al' Yankovic",
+              "Victoria Jackson",
+              "Kevin McCarthy",
+              "Michael Richards",
+            ],
+            "writers": Array [
+              "'Weird Al' Yankovic",
+              "Jay Levey",
+            ],
+          },
+          "highlight": "{\\"actors\\":[\\"'Weird <em>Al</em>' Yankovic\\"],\\"writers\\":[\\"'Weird <b>Al</b>' Yankovic\\"]}",
+          "id": "tt0098546",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Jim Lovell",
+              "Russell Schweickart",
+              "Eugene Cernan",
+              "Michael Collins",
+            ],
+            "writers": Array [],
+          },
+          "highlight": null,
+          "id": "tt0097372",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "Buster Keaton",
+              "Marion Mack",
+              "Glen Cavender",
+              "Jim Farley",
+            ],
+            "writers": Array [
+              "Buster Keaton",
+              "Clyde Bruckman",
+              "Al Boasberg",
+            ],
+          },
+          "highlight": "{\\"writers\\":[\\"<b>Al</b> Boasberg\\"]}",
+          "id": "tt0017925",
+        },
+        Object {
+          "fields": Object {
+            "actors": Array [
+              "James Caan",
+              "Billy Dee Williams",
+              "Jack Warden",
+              "Bernie Casey",
+            ],
+            "writers": Array [
+              "Gale Sayers",
+              "Al Silverman",
+              "William Blinn",
+            ],
+          },
+          "highlight": "{\\"writers\\":[\\"<b>Al</b> Silverman\\"]}",
+          "id": "tt0068315",
+        },
+      ],
+      "sortedBy": null,
+    },
+  },
+}
+`;

--- a/packages/searchkit-schema/tests/support/helper.ts
+++ b/packages/searchkit-schema/tests/support/helper.ts
@@ -5,9 +5,13 @@ import Server from './server'
 
 let agent
 
-export const setupTestServer = (config: SearchkitSchemaConfig | Array<SearchkitSchemaConfig>) => {
+export const setupTestServer = (
+  config: SearchkitSchemaConfig | Array<SearchkitSchemaConfig>,
+  customTypeDefs?: any,
+  customResolvers?: any
+) => {
   const app = express()
-  const appServer = new Server(config)
+  const appServer = new Server(config, customTypeDefs, customResolvers)
   app.use(appServer.setupApolloServer())
   agent = request(app)
 }

--- a/packages/searchkit-schema/tests/support/server.ts
+++ b/packages/searchkit-schema/tests/support/server.ts
@@ -56,9 +56,17 @@ const userTypeDefs = gql`
 
 class Server {
   config: SearchkitSchemaConfig | Array<SearchkitSchemaConfig>
+  customTypeDefs: any
+  customResolvers: any
 
-  constructor(config: SearchkitSchemaConfig | Array<SearchkitSchemaConfig>) {
+  constructor(
+    config: SearchkitSchemaConfig | Array<SearchkitSchemaConfig>,
+    customTypeDefs?: string,
+    customResolvers?: any
+  ) {
     this.config = config
+    this.customTypeDefs = customTypeDefs
+    this.customResolvers = customResolvers
   }
 
   setupApolloServer() {
@@ -81,11 +89,10 @@ class Server {
         }
       })
     } else {
-      // when only one config, the default searchkit
-      td = [...typeDefs, baseTypeDefs]
-      r = withSearchkitResolvers()
+      // when only one config, the default searchkit, which maybe overriden using customTypeDefs
+      td = [...typeDefs, this.customTypeDefs ? this.customTypeDefs : baseTypeDefs]
+      r = withSearchkitResolvers(this.customResolvers)
     }
-
     const server = new ApolloServer({
       typeDefs: td,
       resolvers: r,


### PR DESCRIPTION
Implements feature discussed in https://github.com/searchkit/searchkit/issues/879

Setting highlightedFields in Searchkit config plus a customized ResultHit
graphql type and custom resolver one can request ElasticSearch to generate
highlights for matched words and expose it via graphql to the searchkit
clients.

Resolvers for custom ResultHit fields will receive the highlights in the
"highlight" property, but also added a "rawHit" field containing the hit
record as received from ES, which may come handy in other use cases.

Note: I had to refact `setupTestServer` so that I could add custom graphql typedefs
and resolver to my test, hope it is OK.