### PR TITLE
Canary 35: Double search fix when filter applied to routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-04)
+
+
+### Features
+
+* Add highlight support for matched words ([#880](https://github.com/searchkit/searchkit/issues/880)) ([a7b971e](https://github.com/searchkit/searchkit/commit/a7b971e778bc017f9feb535cd848a7776f82778e))
+* **rangefilter:** allow min / max & dateMin / dateMax to be optional ([#859](https://github.com/searchkit/searchkit/issues/859)) ([a27e774](https://github.com/searchkit/searchkit/commit/a27e774692c9e8860fddc82334aa8910d7422fb1)), closes [#844](https://github.com/searchkit/searchkit/issues/844)
+* add optional postProcessRequest ([#857](https://github.com/searchkit/searchkit/issues/857)) ([fc98800](https://github.com/searchkit/searchkit/commit/fc9880037ad04c7089af22a1bd0bc4ec3715b9c4))
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/docs/docs/guides-url-sync.md
+++ b/docs/docs/guides-url-sync.md
@@ -105,8 +105,7 @@ export default withApollo(withSearchkit(withSearchkitRouting(Search, {
     }
 
     const queryString = qsModule.stringify(newRouteState, {
-      addQueryPrefix: true,
-      arrayFormat: 'repeat',
+      addQueryPrefix: true
     })
 
     return `/type/${typeCategoryURL}${queryString}`

--- a/examples/next/hocs/withApollo.js
+++ b/examples/next/hocs/withApollo.js
@@ -5,12 +5,6 @@ import { InMemoryCache, ApolloProvider, ApolloClient, createHttpLink } from '@ap
 export default withApollo(
   ({ initialState, headers }) => {
     const cache = new InMemoryCache({
-      typePolicies: {
-        FacetSetEntry: {
-          keyFields: false
-        }
-      }
-      // possibleTypes: introspectionResult.possibleTypes
     }).restore(initialState || {})
 
     if (typeof window !== 'undefined') window.cache = cache

--- a/examples/next/pages/index.jsx
+++ b/examples/next/pages/index.jsx
@@ -31,8 +31,7 @@ export default withApollo(withSearchkit(withSearchkitRouting(Search, {
     }
 
     const queryString = qsModule.stringify(newRouteState, {
-      addQueryPrefix: true,
-      arrayFormat: 'repeat',
+      addQueryPrefix: true
     })
 
     return `/type/${typeCategoryURL}${queryString}`

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "includeMergedTags": true,
   "command": {
     "publish": {

--- a/packages/searchkit-cli/CHANGELOG.md
+++ b/packages/searchkit-cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-04)
+
+
+### Features
+
+* Add highlight support for matched words ([#880](https://github.com/searchkit/searchkit/issues/880)) ([a7b971e](https://github.com/searchkit/searchkit/commit/a7b971e778bc017f9feb535cd848a7776f82778e))
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/packages/searchkit-cli/package.json
+++ b/packages/searchkit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/cli",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "lib/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",
   "license": "Apache-2.0",

--- a/packages/searchkit-client/CHANGELOG.md
+++ b/packages/searchkit-client/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-04)
+
+
+### Features
+
+* **rangefilter:** allow min / max & dateMin / dateMax to be optional ([#859](https://github.com/searchkit/searchkit/issues/859)) ([a27e774](https://github.com/searchkit/searchkit/commit/a27e774692c9e8860fddc82334aa8910d7422fb1)), closes [#844](https://github.com/searchkit/searchkit/issues/844)
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/packages/searchkit-client/package.json
+++ b/packages/searchkit-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/client",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",

--- a/packages/searchkit-client/src/components.tsx
+++ b/packages/searchkit-client/src/components.tsx
@@ -35,7 +35,7 @@ export function FilterLink({ filter, resetPagination = true, children }: FilterL
   const routingOptions = useSearchkitRoutingOptions()
   let href
 
-  if (routingOptions) {
+  if (routingOptions && variables) {
     const scs = createSearchState(variables)
     scs.toggleFilter(filter)
     if (resetPagination) scs.resetPage()
@@ -71,7 +71,7 @@ export function PaginationLink({ page, children }: PaginationLinkProps) {
   const from = variables.page.size * (page - 1)
   let href
 
-  if (routingOptions) {
+  if (routingOptions && variables) {
     const scs = createSearchState(variables)
     scs.setPage({
       from,

--- a/packages/searchkit-client/src/searchkit.tsx
+++ b/packages/searchkit-client/src/searchkit.tsx
@@ -256,7 +256,7 @@ export function SearchkitProvider({
   const baseState = Object.assign({}, client.baseSearchState)
   ;[client.searchState, client.setSearchState] = useState(baseState)
   const [pendingSearch, setPendingSearch] = useState(false)
-  const [searchVariables, setSearchVariables] = useState(baseState)
+  const [searchVariables, setSearchVariables] = useState(null)
 
   client.setCallbackFn(() => {
     setPendingSearch(true)

--- a/packages/searchkit-client/src/withSearchkitRouting.tsx
+++ b/packages/searchkit-client/src/withSearchkitRouting.tsx
@@ -76,9 +76,10 @@ export default function withSearchkitRouting(
 
     useEffect(() => {
       const router = getRouting()
-      if (router) {
+      if (router && searchkitVariables) {
         const routeState: RouteState = stateToRoute(searchkitVariables)
         const currentRouteState = router.read()
+
         if (!routeStateEqual(currentRouteState, routeState)) {
           router.write(routeState)
         }
@@ -100,7 +101,7 @@ export default function withSearchkitRouting(
       const routeState = router.read()
       const searchState: SearchState = routeToState(routeState)
       api.setSearchState(searchState)
-
+      api.search()
       return function cleanup() {
         router.dispose()
       }

--- a/packages/searchkit-elastic-ui/CHANGELOG.md
+++ b/packages/searchkit-elastic-ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-04)
+
+**Note:** Version bump only for package @searchkit/elastic-ui
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 **Note:** Version bump only for package @searchkit/elastic-ui

--- a/packages/searchkit-elastic-ui/package.json
+++ b/packages/searchkit-elastic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/elastic-ui",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@searchkit/client": "^3.0.0-canary.34",
+    "@searchkit/client": "^3.0.0-canary.35",
     "use-debounce": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/searchkit-schema/CHANGELOG.md
+++ b/packages/searchkit-schema/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-04)
+
+
+### Features
+
+* Add highlight support for matched words ([#880](https://github.com/searchkit/searchkit/issues/880)) ([a7b971e](https://github.com/searchkit/searchkit/commit/a7b971e778bc017f9feb535cd848a7776f82778e))
+* **rangefilter:** allow min / max & dateMin / dateMax to be optional ([#859](https://github.com/searchkit/searchkit/issues/859)) ([a27e774](https://github.com/searchkit/searchkit/commit/a27e774692c9e8860fddc82334aa8910d7422fb1)), closes [#844](https://github.com/searchkit/searchkit/issues/844)
+* add optional postProcessRequest ([#857](https://github.com/searchkit/searchkit/issues/857)) ([fc98800](https://github.com/searchkit/searchkit/commit/fc9880037ad04c7089af22a1bd0bc4ec3715b9c4))
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/packages/searchkit-schema/package.json
+++ b/packages/searchkit-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/schema",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "lib/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
fix issue where filter isn't being added in the variables at start and apollo calls query then once variables is updated right after, another search is executed.   