### PR TITLE
Release 35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-06)
+
+
+### Features
+
+* Add highlight support for matched words ([#880](https://github.com/searchkit/searchkit/issues/880)) ([a7b971e](https://github.com/searchkit/searchkit/commit/a7b971e778bc017f9feb535cd848a7776f82778e))
+* **rangefilter:** allow min / max & dateMin / dateMax to be optional ([#859](https://github.com/searchkit/searchkit/issues/859)) ([a27e774](https://github.com/searchkit/searchkit/commit/a27e774692c9e8860fddc82334aa8910d7422fb1)), closes [#844](https://github.com/searchkit/searchkit/issues/844)
+* add optional postProcessRequest ([#857](https://github.com/searchkit/searchkit/issues/857)) ([fc98800](https://github.com/searchkit/searchkit/commit/fc9880037ad04c7089af22a1bd0bc4ec3715b9c4))
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/docs/docs/guides-ssr.md
+++ b/docs/docs/guides-ssr.md
@@ -5,14 +5,19 @@ sidebar_label: Server side rendering
 slug: /guides/ssr-server-side-rendering
 ---
 
-Searchkit is able to do server side rendering with a few changes. Due to elastic-ui isn't SSR friendly, you will need to build your own components to do SSR. The first part is to configure apollo to be able to SSR. See [Apollo Server side rendering guide](https://www.apollographql.com/docs/react/performance/server-side-rendering/)
 
+### Configure Apollo Client for SSR
+Searchkit is able to do server side rendering with a few changes. Due to elastic-ui isn't SSR friendly, you will need to build your own components to do SSR. The first part is to configure apollo to be able to SSR. See [Apollo Server side rendering guide](https://www.apollographql.com/docs/react/performance/server-side-rendering/). Take note on the uri, you will need it to be an absolute path instead of a relative path.
+
+### Searchkit Routing Configuration
 Then you must enable [url synchronization](https://www.searchkit.co/docs/guides/url-synchronization).
 
 An example of the configuration can be seen below. You can see it in [action here](https://demo.searchkit.co/ssr-example?query=test)
 
+### SEO
 See [SEO tips](https://www.searchkit.co/docs/guides/seo-tips) for more information on how SSR and other features can improve SEO on your search.
 
+### Example
 ```jsx
 import { useQuery, gql } from '@apollo/client'
 import { withSearchkit, useSearchkitVariables, withSearchkitRouting } from '@searchkit/client'

--- a/examples/next/components/searchkit/Hits.jsx
+++ b/examples/next/components/searchkit/Hits.jsx
@@ -20,9 +20,9 @@ export const HitsGrid = ({ data }) => (
 export const HitsList = ({ data }) => (
   <EuiFlexGrid>
     {data?.results.hits.items.map((hit) => (
-      <EuiFlexItem>
+      <EuiFlexItem key={hit.id}>
 
-        <EuiFlexGroup gutterSize="xl" key={hit.id}>
+        <EuiFlexGroup gutterSize="xl">
           <EuiFlexItem>
             <EuiFlexGroup>
               <EuiFlexItem grow={false}>

--- a/examples/next/hocs/withApollo.js
+++ b/examples/next/hocs/withApollo.js
@@ -4,14 +4,7 @@ import { InMemoryCache, ApolloProvider, ApolloClient, createHttpLink } from '@ap
 
 export default withApollo(
   ({ initialState, headers }) => {
-    const cache = new InMemoryCache({
-      typePolicies: {
-        FacetSetEntry: {
-          keyFields: false
-        }
-      }
-      // possibleTypes: introspectionResult.possibleTypes
-    }).restore(initialState || {})
+    const cache = new InMemoryCache({}).restore(initialState || {})
 
     if (typeof window !== 'undefined') window.cache = cache
 
@@ -19,6 +12,7 @@ export default withApollo(
       ssrMode: true,
       link: createHttpLink({
         uri: '/api/graphql',
+       // uri: 'http://localhost:3000/api/graphql',
         credentials: 'same-origin',
         headers: {
           cookie: headers?.cookie

--- a/examples/next/pages/index.jsx
+++ b/examples/next/pages/index.jsx
@@ -31,8 +31,7 @@ export default withApollo(withSearchkit(withSearchkitRouting(Search, {
     }
 
     const queryString = qsModule.stringify(newRouteState, {
-      addQueryPrefix: true,
-      arrayFormat: 'repeat',
+      addQueryPrefix: true
     })
 
     return `/type/${typeCategoryURL}${queryString}`

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "includeMergedTags": true,
   "command": {
     "publish": {

--- a/packages/searchkit-cli/CHANGELOG.md
+++ b/packages/searchkit-cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-06)
+
+
+### Features
+
+* Add highlight support for matched words ([#880](https://github.com/searchkit/searchkit/issues/880)) ([a7b971e](https://github.com/searchkit/searchkit/commit/a7b971e778bc017f9feb535cd848a7776f82778e))
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/packages/searchkit-cli/package.json
+++ b/packages/searchkit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/cli",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "lib/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",
   "license": "Apache-2.0",

--- a/packages/searchkit-client/CHANGELOG.md
+++ b/packages/searchkit-client/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-06)
+
+
+### Features
+
+* **rangefilter:** allow min / max & dateMin / dateMax to be optional ([#859](https://github.com/searchkit/searchkit/issues/859)) ([a27e774](https://github.com/searchkit/searchkit/commit/a27e774692c9e8860fddc82334aa8910d7422fb1)), closes [#844](https://github.com/searchkit/searchkit/issues/844)
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/packages/searchkit-client/package.json
+++ b/packages/searchkit-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/client",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",

--- a/packages/searchkit-client/src/__tests__/components.test.tsx
+++ b/packages/searchkit-client/src/__tests__/components.test.tsx
@@ -121,7 +121,7 @@ describe('components', () => {
           "size": 20,
         },
         "query": "",
-        "sortBy": null,
+        "sortBy": "",
       }
     `)
   })
@@ -165,7 +165,7 @@ describe('components', () => {
           "size": 10,
         },
         "query": "test",
-        "sortBy": undefined,
+        "sortBy": "",
       }
     `)
   })

--- a/packages/searchkit-client/src/searchkit.tsx
+++ b/packages/searchkit-client/src/searchkit.tsx
@@ -213,7 +213,7 @@ export class SearchkitClient extends SearchkitClientState {
         size: 10,
         from: 0
       },
-      sortBy: null
+      sortBy: ''
     }
     this.onSearch = null
   }

--- a/packages/searchkit-client/src/withSearchkitRouting.tsx
+++ b/packages/searchkit-client/src/withSearchkitRouting.tsx
@@ -34,7 +34,7 @@ export const stateToRouteFn = (searchState) => {
 
 export const routeToStateFn = (routeState) => ({
   query: routeState.query || '',
-  sortBy: routeState.sort,
+  sortBy: routeState.sort || '',
   filters: routeState.filters || [],
   page: {
     size: Number(routeState.size) || 10,
@@ -100,6 +100,7 @@ export default function withSearchkitRouting(
       const routeState = router.read()
       const searchState: SearchState = routeToState(routeState)
       api.setSearchState(searchState)
+      api.search()
 
       return function cleanup() {
         router.dispose()

--- a/packages/searchkit-elastic-ui/CHANGELOG.md
+++ b/packages/searchkit-elastic-ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-06)
+
+**Note:** Version bump only for package @searchkit/elastic-ui
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 **Note:** Version bump only for package @searchkit/elastic-ui

--- a/packages/searchkit-elastic-ui/package.json
+++ b/packages/searchkit-elastic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/elastic-ui",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@searchkit/client": "^3.0.0-canary.34",
+    "@searchkit/client": "^3.0.0-canary.35",
     "use-debounce": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/searchkit-schema/CHANGELOG.md
+++ b/packages/searchkit-schema/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.35](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.35) (2021-06-06)
+
+
+### Features
+
+* Add highlight support for matched words ([#880](https://github.com/searchkit/searchkit/issues/880)) ([a7b971e](https://github.com/searchkit/searchkit/commit/a7b971e778bc017f9feb535cd848a7776f82778e))
+* **rangefilter:** allow min / max & dateMin / dateMax to be optional ([#859](https://github.com/searchkit/searchkit/issues/859)) ([a27e774](https://github.com/searchkit/searchkit/commit/a27e774692c9e8860fddc82334aa8910d7422fb1)), closes [#844](https://github.com/searchkit/searchkit/issues/844)
+* add optional postProcessRequest ([#857](https://github.com/searchkit/searchkit/issues/857)) ([fc98800](https://github.com/searchkit/searchkit/commit/fc9880037ad04c7089af22a1bd0bc4ec3715b9c4))
+
+
+
+
+
 # [3.0.0-canary.34](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.27...v3.0.0-canary.34) (2021-06-02)
 
 

--- a/packages/searchkit-schema/package.json
+++ b/packages/searchkit-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/schema",
-  "version": "3.0.0-canary.34",
+  "version": "3.0.0-canary.35",
   "main": "lib/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bug fix: search was not called on client side render, therefore variables contained the baseState only even though the url contains searchState.
- Bug fix: Issue with sortBy being either null or not provided in variables causing a miss in apollo cache and resulting in a XHR request to server on client hydrate
