### PR TITLE
wrong types in example

### DIFF
--- a/examples/indexer/config.ts
+++ b/examples/indexer/config.ts
@@ -142,7 +142,7 @@ withConfig({
       sourceOptions: {
         path: 'imdbRating',
         transform: (str) => {
-          if (!str || parseFloat(str) === NaN) return null
+          if (!str || isNaN(parseFloat(str))) return 0
           return parseFloat(str)
         }
       }


### PR DESCRIPTION
The return cannot be `null` as the type for `transform` requires `int | string`. Also, the equality comparison with NaN always evaluates to false, so replacing with `isNan` instead.