### PR TITLE
WIP: Add EuiFacetButton with more/less func

### DIFF
--- a/packages/searchkit-elastic-ui/src/Facets/ListFacet/index.tsx
+++ b/packages/searchkit-elastic-ui/src/Facets/ListFacet/index.tsx
@@ -1,8 +1,14 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import { EuiFacetGroup, EuiTitle, EuiFacetButton } from '@elastic/eui'
 import { useSearchkit, FilterLink, FilterLinkClickRef } from '@searchkit/client'
 
 export const ListFacet = ({ facet, loading }) => {
+  /*FIXME Read from RefinementSelectFacet prop?"*/
+  const elementsFromConfig = 4
+  const difference = 2
+
+  const [elements, setElements] = useState(elementsFromConfig)
+
   const api = useSearchkit()
 
   const entries = facet.entries.map((entry) => {
@@ -26,12 +32,38 @@ export const ListFacet = ({ facet, loading }) => {
     )
   })
 
+  /* Prepare conditions for more/less buttons"*/
+  const loadedEntries = entries.length
+  const showMore = elements < loadedEntries
+  const showLess = elements <= loadedEntries && elements > difference
+  entries.length = elements
+
   return (
     <>
       <EuiTitle size="xxs">
         <h3>{facet.label}</h3>
       </EuiTitle>
       <EuiFacetGroup>{entries}</EuiFacetGroup>
+      {showMore && (
+        <EuiFacetButton
+          aria-label="show more"
+          onClick={() => {
+            setElements(elements + difference)
+          }}
+        >
+          more
+        </EuiFacetButton>
+      )}
+      {showLess && (
+        <EuiFacetButton
+          aria-label="show less"
+          onClick={() => {
+            setElements(elements - difference)
+          }}
+        >
+          less
+        </EuiFacetButton>
+      )}
     </>
   )
 }


### PR DESCRIPTION
**Note**: This is more of an **_idea_** than a PR. I am happy to implement alternative ways, such as using graphql queries, but would need some assistance to do so.

### Changes

**Current State**: ListFacet has no possibility to increase or decrease the list of facets.
**Desired State**:  Add a more/less button at the end of each facet list.

### Description
Currently all facets are loaded via graphql query and filtered in the ListFacet Component.
Advantage: No need for a new query every time the user clicks the button
Disadvantage: More facets are loaded than displayed

### Open for discussion
The component now has a state. Maybe that is not desired.

### Fixes needed
If the user selects a facet. The list reloads, loosing all information about the more/less-state and the selected facet maybe hidden.

### Todos
(for the current state):
* Button text content read from i18n configuration
* The information about how many elements should be displayed and how many should be "uncovered" with one click has to happen from the app-wide configuration. Use `RefinementSelectFacet` or read `searchkitConfig`?
* Write Unit Test