### PR TITLE
WIP: Removing ElasticSearch client

### DIFF
--- a/packages/searchkit-schema/src/core/SearchkitRequest.ts
+++ b/packages/searchkit-schema/src/core/SearchkitRequest.ts
@@ -8,19 +8,21 @@ import QueryManager from './QueryManager'
 import { filterTransform } from './FacetsFns'
 
 export interface SearchClient {
-  search<TContext, TRequestBody, TResponse>(params?: SearchRequest<TRequestBody>): Promise<SearchResult<TResponse, TContext>>
+  search<TContext, TRequestBody, TResponse>(
+    params?: SearchRequest<TRequestBody>
+  ): Promise<SearchResult<TResponse, TContext>>
 }
 
 export interface SearchResult<TResponse, TContext> {
-  body: TResponse,
+  body: TResponse
   meta: {
     context: TContext
   }
 }
 
 export interface SearchRequest<T> {
-  index: string | string[];
-  body: T;
+  index: string | string[]
+  body: T
 }
 
 export interface SearchResponse<T> {
@@ -83,7 +85,7 @@ export default class SearchkitRequest {
     private config: SearchkitConfig,
     private baseFilters: Array<Record<string, unknown>>,
     private facets: Array<BaseFacet>,
-    client?: SearchClient,
+    client?: SearchClient
   ) {
     this.client = client ?? this.getDefaultClient()
 

--- a/packages/searchkit-schema/src/core/SearchkitRequest.ts
+++ b/packages/searchkit-schema/src/core/SearchkitRequest.ts
@@ -6,9 +6,12 @@ import ESQueryError from '../utils/ESQueryError'
 import { BaseFacet } from '../facets'
 import QueryManager from './QueryManager'
 import { filterTransform } from './FacetsFns'
+import {
+  ApiResponse,
+} from "@elastic/elasticsearch/lib/Transport";
 
 export interface SearchClient {
-  search(params?: SearchRequest<any>): Promise<SearchResponse<any>>
+  search<TContext, TRequestBody, TResponse>(params?: SearchRequest<TRequestBody>): Promise<ApiResponse<TResponse, TContext>>
 }
 
 export interface SearchRequest<T> {
@@ -145,9 +148,9 @@ export default class SearchkitRequest {
     )
   }
 
-  private async executeQuery(esQuery): Promise<SearchResponse<any>> {
+  private async executeQuery<T>(esQuery): Promise<T> {
     try {
-      const response = await this.client.search<SearchResponse<any>>({
+      const response = await this.client.search<null, SearchRequest<T>, SearchResponse<T>>({
         index: this.config.index,
         body: esQuery
       })

--- a/packages/searchkit-schema/src/core/SearchkitRequest.ts
+++ b/packages/searchkit-schema/src/core/SearchkitRequest.ts
@@ -7,6 +7,15 @@ import { BaseFacet } from '../facets'
 import QueryManager from './QueryManager'
 import { filterTransform } from './FacetsFns'
 
+export interface SearchClient {
+  search(params?: SearchRequest<any>): Promise<SearchResponse<any>>
+}
+
+export interface SearchRequest<T> {
+  index: string | string[];
+  body: T;
+}
+
 export interface SearchResponse<T> {
   took: number
   timed_out: boolean
@@ -60,9 +69,10 @@ const keepaliveAgent = new HttpAgent()
 
 export default class SearchkitRequest {
   private dataloader: any
-  private client: Client
+  // private client: Client
 
   constructor(
+    private client: SearchClient,
     private queryManager: QueryManager,
     private config: SearchkitConfig,
     private baseFilters: Array<Record<string, unknown>>,


### PR DESCRIPTION
To make sure Searchkit is compatible with both search clients (ElasticSearch and OpenSearch), this PR aims to remove the tight dependency on the ElasticSearch client.