### PR TITLE
Allow default sorting option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.52](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.52) (2022-03-22)
+
+**Note:** Version bump only for package searchkit
+
+
+
+
+
 # [3.0.0-canary.51](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.51) (2022-03-16)
 
 **Note:** Version bump only for package searchkit

--- a/docs/docs/searchkit-sdk.md
+++ b/docs/docs/searchkit-sdk.md
@@ -856,7 +856,12 @@ const searchkitConfig = {
   }),
   sortOptions: [
     {id: 'relevance', label: 'Relevance', field: '_score'},
-    {id: 'released', label: 'Recent Releases', field: {released: 'desc'}},
+    {
+      id: 'released',
+      label: 'Recent Releases',
+      field: {released: 'desc'},
+      defaultOption: true,
+    },
     {
       id: 'title-released',
       label: 'Recent titles',
@@ -890,10 +895,12 @@ const response = await request
 
 #### Options
 
-| Option | Description                                |
-| :----- | :----------------------------------------- |
-| id     | Unique id. Used to specify what to sort by |
-| label  | label to be displayed in frontend          |
+| Option | Description |
+| :-- | :-- |
+| id | Unique id. Used to specify what to sort by |
+| label | label to be displayed in frontend |
+| field | Elasticsearch Sorting field. See above for examples of complex sorting field configurations |
+| defaultOption | Boolean. If no sorting option is selected, this will be the sort option chosen as default |
 
 Will give back the sorting name and sorting options in the response
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0-canary.51",
+  "version": "3.0.0-canary.52",
   "includeMergedTags": true,
   "command": {
     "publish": {

--- a/packages/searchkit-cli/CHANGELOG.md
+++ b/packages/searchkit-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.52](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.52) (2022-03-22)
+
+**Note:** Version bump only for package @searchkit/cli
+
+
+
+
+
 # [3.0.0-canary.51](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.51) (2022-03-16)
 
 **Note:** Version bump only for package @searchkit/cli

--- a/packages/searchkit-cli/package.json
+++ b/packages/searchkit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/cli",
-  "version": "3.0.0-canary.51",
+  "version": "3.0.0-canary.52",
   "main": "lib/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",
   "license": "Apache-2.0",

--- a/packages/searchkit-client/CHANGELOG.md
+++ b/packages/searchkit-client/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.52](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.52) (2022-03-22)
+
+**Note:** Version bump only for package @searchkit/client
+
+
+
+
+
 # [3.0.0-canary.51](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.51) (2022-03-16)
 
 **Note:** Version bump only for package @searchkit/client

--- a/packages/searchkit-client/package.json
+++ b/packages/searchkit-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/client",
-  "version": "3.0.0-canary.51",
+  "version": "3.0.0-canary.52",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",

--- a/packages/searchkit-elastic-ui/CHANGELOG.md
+++ b/packages/searchkit-elastic-ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.52](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.52) (2022-03-22)
+
+**Note:** Version bump only for package @searchkit/elastic-ui
+
+
+
+
+
 # [3.0.0-canary.51](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.51) (2022-03-16)
 
 **Note:** Version bump only for package @searchkit/elastic-ui

--- a/packages/searchkit-elastic-ui/package.json
+++ b/packages/searchkit-elastic-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/elastic-ui",
-  "version": "3.0.0-canary.51",
+  "version": "3.0.0-canary.52",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
@@ -40,7 +40,7 @@
     "@apollo/client": "^3.5.8",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^34.0.0",
-    "@searchkit/client": "^3.0.0-canary.51",
+    "@searchkit/client": "^3.0.0-canary.52",
     "@types/react": "^17.0.13",
     "moment": "^2.29.1",
     "react": "^17.0.1",

--- a/packages/searchkit-schema/CHANGELOG.md
+++ b/packages/searchkit-schema/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.52](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.52) (2022-03-22)
+
+**Note:** Version bump only for package @searchkit/schema
+
+
+
+
+
 # [3.0.0-canary.51](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.51) (2022-03-16)
 
 **Note:** Version bump only for package @searchkit/schema

--- a/packages/searchkit-schema/package.json
+++ b/packages/searchkit-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/schema",
-  "version": "3.0.0-canary.51",
+  "version": "3.0.0-canary.52",
   "main": "lib/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "7.13.0",
-    "@searchkit/sdk": "^3.0.0-canary.51",
+    "@searchkit/sdk": "^3.0.0-canary.52",
     "dataloader": "^2.0.0",
     "graphql-tag": "^2.10.3",
     "lodash": "^4.17.21"

--- a/packages/searchkit-sdk/CHANGELOG.md
+++ b/packages/searchkit-sdk/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0-canary.52](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.52) (2022-03-22)
+
+**Note:** Version bump only for package @searchkit/sdk
+
+
+
+
+
 # [3.0.0-canary.51](https://github.com/searchkit/searchkit/compare/v3.0.0-canary.46...v3.0.0-canary.51) (2022-03-16)
 
 **Note:** Version bump only for package @searchkit/sdk

--- a/packages/searchkit-sdk/package.json
+++ b/packages/searchkit-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@searchkit/sdk",
-  "version": "3.0.0-canary.51",
+  "version": "3.0.0-canary.52",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "author": "Joseph McElroy <phoey1@gmail.com>",

--- a/packages/searchkit-sdk/src/index.ts
+++ b/packages/searchkit-sdk/src/index.ts
@@ -104,6 +104,15 @@ export class SearchkitRequest {
     this.queryManager = new QueryManager()
     this.transporter = !transporter ? new FetchClientTransporter(config) : transporter
     this.transformer = new ElasticSearchResponseTransformer()
+    this.handleDefaults()
+  }
+
+  handleDefaults(): void {
+    const defaultSortOptionId =
+      this.config.sortOptions && this.config.sortOptions.find((option) => option.defaultOption)
+    const defaultSortOption =
+      defaultSortOptionId && getSortOption(defaultSortOptionId.id, this.config.sortOptions)
+    this.queryManager.setSortBy(defaultSortOption)
   }
 
   query(query: string): SearchkitRequest {

--- a/packages/searchkit-sdk/tests/__snapshots__/sortBy.test.ts.snap
+++ b/packages/searchkit-sdk/tests/__snapshots__/sortBy.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Hit Results Query 2`] = `
+exports[`SortBy Default behaviour 2`] = `
 Object {
   "facets": null,
   "hits": Object {
@@ -412,7 +412,435 @@ Object {
   "summary": Object {
     "appliedFilters": Array [],
     "disabledFilters": Array [],
-    "query": "test",
+    "query": "",
+    "sortOptions": Array [
+      Object {
+        "id": "relevance",
+        "label": "Relevance",
+      },
+      Object {
+        "id": "released",
+        "label": "Recent Releases",
+      },
+    ],
+    "total": 4162,
+  },
+}
+`;
+
+exports[`SortBy default option 2`] = `
+Object {
+  "facets": null,
+  "hits": Object {
+    "items": Array [
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Christian Bale",
+            "Heath Ledger",
+            "Aaron Eckhart",
+            "Michael Caine",
+          ],
+          "awards": "Won 2 Oscars. Another 94 wins & 69 nominations.",
+          "countries": Array [
+            "USA",
+            "UK",
+          ],
+          "genres": Array [
+            "Action",
+            "Crime",
+            "Drama",
+          ],
+          "imdbId": "tt0468569",
+          "imdbRating": 9,
+          "imdbVotes": 1133701,
+          "metaScore": 82,
+          "plot": "When Batman, Gordon and Harvey Dent launch an assault on the mob, they let the clown out of the box, the Joker, bent on turning Gotham on itself and bringing any heroes down to his level.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_SX300.jpg",
+          "rated": Array [
+            "PG-13",
+          ],
+          "released": "2008-07-18",
+          "runtimeMinutes": 152,
+          "title": "The Dark Knight",
+          "type": "Movie",
+          "writers": Array [
+            "Jonathan Nolan",
+            "Christopher Nolan",
+            "David S. Goyer",
+            "Bob Kane",
+          ],
+          "year": 2008,
+        },
+        "highlight": undefined,
+        "id": "tt0468569",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Tim Roth",
+            "Amanda Plummer",
+            "Laura Lovelace",
+            "John Travolta",
+          ],
+          "awards": "Won 1 Oscar. Another 61 wins & 46 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Crime",
+            "Drama",
+            "Thriller",
+          ],
+          "imdbId": "tt0110912",
+          "imdbRating": 9,
+          "imdbVotes": 895306,
+          "metaScore": 94,
+          "plot": "The lives of two mob hit men, a boxer, a gangster's wife, and a pair of diner bandits intertwine in four tales of violence and redemption.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMjE0ODk2NjczOV5BMl5BanBnXkFtZTYwNDQ0NDg4._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "1994-10-14",
+          "runtimeMinutes": 154,
+          "title": "Pulp Fiction",
+          "type": "Movie",
+          "writers": Array [
+            "Quentin Tarantino",
+            "Roger Avary",
+          ],
+          "year": 1994,
+        },
+        "highlight": undefined,
+        "id": "tt0110912",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Noel Appleby",
+            "Alexandra Astin",
+            "Sean Astin",
+            "David Aston",
+          ],
+          "awards": "Won 11 Oscars. Another 122 wins & 73 nominations.",
+          "countries": Array [
+            "USA",
+            "New Zealand",
+          ],
+          "genres": Array [
+            "Action",
+            "Adventure",
+            "Fantasy",
+          ],
+          "imdbId": "tt0167260",
+          "imdbRating": 8.9,
+          "imdbVotes": 826369,
+          "metaScore": 94,
+          "plot": "Gandalf and Aragorn lead the World of Men against Sauron's army to draw his gaze from Frodo and Sam as they approach Mount Doom with the One Ring.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMjE4MjA1NTAyMV5BMl5BanBnXkFtZTcwNzM1NDQyMQ@@._V1_SX300.jpg",
+          "rated": Array [
+            "PG-13",
+          ],
+          "released": "2003-12-17",
+          "runtimeMinutes": 201,
+          "title": "The Lord of the Rings: The Return of the King",
+          "type": "Movie",
+          "writers": Array [
+            "J.R.R. Tolkien",
+            "Fran Walsh",
+            "Philippa Boyens",
+            "Peter Jackson",
+          ],
+          "year": 2003,
+        },
+        "highlight": undefined,
+        "id": "tt0167260",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Morgan Freeman",
+            "Andrew Kevin Walker",
+            "Daniel Zacapa",
+            "Brad Pitt",
+          ],
+          "awards": "Nominated for 1 Oscar. Another 25 wins & 18 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Crime",
+            "Mystery",
+            "Thriller",
+          ],
+          "imdbId": "tt0114369",
+          "imdbRating": 8.7,
+          "imdbVotes": 672372,
+          "metaScore": 65,
+          "plot": "Two detectives, a rookie and a veteran, hunt a serial killer who uses the seven deadly sins as his modus operandi.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTQwNTU3MTE4NF5BMl5BanBnXkFtZTcwOTgxNDM2Mg@@._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "1995-09-22",
+          "runtimeMinutes": 127,
+          "title": "Se7en",
+          "type": "Movie",
+          "writers": Array [
+            "Andrew Kevin Walker",
+          ],
+          "year": 1995,
+        },
+        "highlight": undefined,
+        "id": "tt0114369",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Michael Berryman",
+            "Peter Brocco",
+            "Dean R. Brooks",
+            "Alonzo Brown",
+          ],
+          "awards": "Won 5 Oscars. Another 30 wins & 12 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Drama",
+          ],
+          "imdbId": "tt0073486",
+          "imdbRating": 8.8,
+          "imdbVotes": 481493,
+          "metaScore": 79,
+          "plot": "Upon admittance to a mental institution, a brash rebel rallies the patients to take on the oppressive head nurse.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTk5OTA4NTc0NF5BMl5BanBnXkFtZTcwNzI5Mzg3OA@@._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "1975-11-21",
+          "runtimeMinutes": 133,
+          "title": "One Flew Over the Cuckoo's Nest",
+          "type": "Movie",
+          "writers": Array [
+            "Lawrence Hauben",
+            "Bo Goldman",
+            "Ken Kesey",
+            "Dale Wasserman",
+          ],
+          "year": 1975,
+        },
+        "highlight": undefined,
+        "id": "tt0073486",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Russell Crowe",
+            "Joaquin Phoenix",
+            "Connie Nielsen",
+            "Oliver Reed",
+          ],
+          "awards": "Won 5 Oscars. Another 51 wins & 80 nominations.",
+          "countries": Array [
+            "USA",
+            "UK",
+          ],
+          "genres": Array [
+            "Action",
+            "Adventure",
+            "Drama",
+          ],
+          "imdbId": "tt0172495",
+          "imdbRating": 8.5,
+          "imdbVotes": 649422,
+          "metaScore": 64,
+          "plot": "When a Roman general is betrayed and his family murdered by an emperor's corrupt son, he comes to Rome as a gladiator to seek revenge.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTgwMzQzNTQ1Ml5BMl5BanBnXkFtZTgwMDY2NTYxMTE@._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "2000-05-05",
+          "runtimeMinutes": 155,
+          "title": "Gladiator",
+          "type": "Movie",
+          "writers": Array [
+            "David Franzoni",
+            "John Logan",
+            "William Nicholson",
+          ],
+          "year": 2000,
+        },
+        "highlight": undefined,
+        "id": "tt0172495",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Andrew Lincoln",
+            "Steven Yeun",
+            "Chandler Riggs",
+            "Norman Reedus",
+          ],
+          "awards": "Nominated for 1 Golden Globe. Another 15 wins & 50 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Drama",
+            "Horror",
+            "Thriller",
+          ],
+          "imdbId": "tt1520211",
+          "imdbRating": 8.8,
+          "imdbVotes": 357942,
+          "plot": "Police officer Rick Grimes leads a group of survivors in a world overrun by zombies.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BNzU0MjIzNzY1MV5BMl5BanBnXkFtZTgwNjgxNTg4MDE@._V1_SX300.jpg",
+          "rated": Array [
+            "TV-14",
+          ],
+          "released": "2010-10-31",
+          "runtimeMinutes": 45,
+          "title": "The Walking Dead",
+          "type": "Series",
+          "writers": Array [
+            "Frank Darabont",
+          ],
+          "year": 2010,
+        },
+        "highlight": undefined,
+        "id": "tt1520211",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Jim Carrey",
+            "Kate Winslet",
+            "Gerry Robert Byrne",
+            "Elijah Wood",
+          ],
+          "awards": "Won 1 Oscar. Another 46 wins & 54 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Drama",
+            "Romance",
+            "Sci-Fi",
+          ],
+          "imdbId": "tt0338013",
+          "imdbRating": 8.4,
+          "imdbVotes": 467149,
+          "metaScore": 89,
+          "plot": "A couple undergo a procedure to erase each other from their memories when their relationship turns sour, but it is only through the process of loss that they discover what they had to begin with.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTY4NzcwODg3Nl5BMl5BanBnXkFtZTcwNTEwOTMyMw@@._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "2004-03-19",
+          "runtimeMinutes": 108,
+          "title": "Eternal Sunshine of the Spotless Mind",
+          "type": "Movie",
+          "writers": Array [
+            "Charlie Kaufman",
+            "Michel Gondry",
+            "Pierre Bismuth",
+          ],
+          "year": 2004,
+        },
+        "highlight": undefined,
+        "id": "tt0338013",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Marlon Brando",
+            "Martin Sheen",
+            "Robert Duvall",
+            "Frederic Forrest",
+          ],
+          "awards": "Won 2 Oscars. Another 17 wins & 30 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Drama",
+            "War",
+          ],
+          "imdbId": "tt0078788",
+          "imdbRating": 8.5,
+          "imdbVotes": 329282,
+          "metaScore": 90,
+          "plot": "During the U.S.-Viet Nam War, Captain Willard is sent on a dangerous mission into Cambodia to assassinate a renegade colonel who has set himself up as a god among a local tribe.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMTcyMzQ5NDM4OV5BMl5BanBnXkFtZTcwODUwNDg3OA@@._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "1979-08-15",
+          "runtimeMinutes": 153,
+          "title": "Apocalypse Now",
+          "type": "Movie",
+          "writers": Array [
+            "John Milius",
+            "Francis Ford Coppola",
+            "Michael Herr",
+          ],
+          "year": 1979,
+        },
+        "highlight": undefined,
+        "id": "tt0078788",
+      },
+      Object {
+        "fields": Object {
+          "actors": Array [
+            "Ellen Burstyn",
+            "Jared Leto",
+            "Jennifer Connelly",
+            "Marlon Wayans",
+          ],
+          "awards": "Nominated for 1 Oscar. Another 27 wins & 36 nominations.",
+          "countries": Array [
+            "USA",
+          ],
+          "genres": Array [
+            "Drama",
+          ],
+          "imdbId": "tt0180093",
+          "imdbRating": 8.4,
+          "imdbVotes": 406824,
+          "metaScore": 68,
+          "plot": "The drug-induced utopias of four Coney Island individuals are shattered when their addictions become stronger.",
+          "poster": "https://s3-eu-west-1.amazonaws.com/imdbimages/images/MV5BMzM2OTYwMTY4Nl5BMl5BanBnXkFtZTcwMjU1Njg3OA@@._V1_SX300.jpg",
+          "rated": Array [
+            "R",
+          ],
+          "released": "2000-10-27",
+          "runtimeMinutes": 102,
+          "title": "Requiem for a Dream",
+          "type": "Movie",
+          "writers": Array [
+            "Hubert Selby Jr.",
+            "Darren Aronofsky",
+          ],
+          "year": 2000,
+        },
+        "highlight": undefined,
+        "id": "tt0180093",
+      },
+    ],
+    "page": Object {
+      "from": 0,
+      "pageNumber": 0,
+      "size": 10,
+      "total": 4162,
+      "totalPages": 417,
+    },
+  },
+  "sortedBy": "released",
+  "summary": Object {
+    "appliedFilters": Array [],
+    "disabledFilters": Array [],
+    "query": "",
     "sortOptions": Array [
       Object {
         "id": "relevance",


### PR DESCRIPTION
fixes #1093 

Allows a default sort option to be used when no sort is specified. 

```
sortOptions: [
    {id: 'relevance', label: 'Relevance', field: '_score'},
    {
      id: 'released',
      label: 'Recent Releases',
      field: {released: 'desc'},
      defaultOption: true,
    },
    {
      id: 'title-released',
      label: 'Recent titles',
      field: [{released: 'desc'}, {title: 'desc'}],
    },
    {
      id: 'multiple_sort',
      label: 'Multiple sort',
      field: [
        {post_date: {order: 'asc'}},
        'user',
        {name: 'desc'},
        {age: 'desc'},
        '_score',
      ],
    },
  ],```