### PR TITLE
import lodash methods

### DIFF
--- a/examples/next/components/geosearch-examples/maps.jsx
+++ b/examples/next/components/geosearch-examples/maps.jsx
@@ -1,7 +1,7 @@
 import { useSearchkit, useSearchkitVariables } from '@searchkit/client'
 import { useEffect, useRef, useState } from 'react'
 import debounce from 'debounce'
-import { xor } from 'lodash'
+import xor from 'lodash/xor'
 
 let map
 

--- a/packages/searchkit-cli/src/lib.ts
+++ b/packages/searchkit-cli/src/lib.ts
@@ -1,5 +1,5 @@
 import { Client } from '@elastic/elasticsearch'
-import _ from 'lodash'
+import flatMap from 'lodash/flatMap'
 import parse from 'date-fns/parse'
 import formatISO from 'date-fns/formatISO'
 
@@ -154,7 +154,7 @@ export const indexDocs = async (config) => {
   })
   const docs = await getDocs(config)
   try {
-    const cmds = _.flatMap(docs, (doc) => [
+    const cmds = flatMap(docs, (doc) => [
       { index: { _index: config.index, _id: doc.id, _type: config.type } },
       doc
     ])

--- a/packages/searchkit-client/src/searchkit.tsx
+++ b/packages/searchkit-client/src/searchkit.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import isEqual from 'fast-deep-equal'
-import { isUndefined } from 'lodash'
+import isUndefined from 'lodash/isUndefined'
 
 export interface Filter {
   identifier: string

--- a/packages/searchkit-sdk/src/core/RequestBodyBuilder.ts
+++ b/packages/searchkit-sdk/src/core/RequestBodyBuilder.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash'
+import merge from 'lodash/merge'
 import { SearchkitConfig } from '../'
 import { BaseFacet } from '../facets'
 import QueryManager from './QueryManager'

--- a/packages/searchkit-sdk/src/facets/DateRangeFacet.ts
+++ b/packages/searchkit-sdk/src/facets/DateRangeFacet.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import isUndefined from 'lodash/isUndefined'
 import { DateRangeFilter } from '../core/QueryManager'
 import { BaseFacet } from './BaseFacet'
 
@@ -23,8 +23,8 @@ class DateRangeFacet implements BaseFacet {
 
   getFilters(filters: Array<DateRangeFilter>) {
     const rangeFilter: { gte?: string; lte?: string } = {}
-    if (!_.isUndefined(filters[0].dateMin)) rangeFilter.gte = filters[0].dateMin
-    if (!_.isUndefined(filters[0].dateMax)) rangeFilter.lte = filters[0].dateMax
+    if (!isUndefined(filters[0].dateMin)) rangeFilter.gte = filters[0].dateMin
+    if (!isUndefined(filters[0].dateMax)) rangeFilter.lte = filters[0].dateMax
     return { range: { [this.config.field]: rangeFilter } }
   }
 

--- a/packages/searchkit-sdk/src/facets/HierarchicalMenuFacet.ts
+++ b/packages/searchkit-sdk/src/facets/HierarchicalMenuFacet.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import QueryManager, { HierarchicalValueFilter } from '../core/QueryManager'
 import { BaseFacet } from './BaseFacet'
 

--- a/packages/searchkit-sdk/src/facets/MultiQueryOptionsFacet.ts
+++ b/packages/searchkit-sdk/src/facets/MultiQueryOptionsFacet.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import { ValueFilter } from '../core/QueryManager'
 import { BaseFacet } from './BaseFacet'
 

--- a/packages/searchkit-sdk/src/facets/RangeFacet.ts
+++ b/packages/searchkit-sdk/src/facets/RangeFacet.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import isUndefined from 'lodash/isUndefined'
 import { RangeFilter } from '../core/QueryManager'
 import { BaseFacet } from './BaseFacet'
 
@@ -29,8 +29,8 @@ class RangeFacet implements BaseFacet {
 
   getFilters(filters: Array<RangeFilter>) {
     const rangeFilter: { gte?: number; lte?: number } = {}
-    if (!_.isUndefined(filters[0].min)) rangeFilter.gte = filters[0].min
-    if (!_.isUndefined(filters[0].max)) rangeFilter.lte = filters[0].max
+    if (!isUndefined(filters[0].min)) rangeFilter.gte = filters[0].min
+    if (!isUndefined(filters[0].max)) rangeFilter.lte = filters[0].max
     return { range: { [this.config.field]: rangeFilter } }
   }
 

--- a/packages/searchkit-sdk/src/filters/GeoBoundingBoxFilter.ts
+++ b/packages/searchkit-sdk/src/filters/GeoBoundingBoxFilter.ts
@@ -1,4 +1,5 @@
-import { omitBy, isNil } from 'lodash'
+import isNil from 'lodash/isNil'
+import omitBy from 'lodash/omitBy'
 import { GeoBoundingBoxFilter } from '../core/QueryManager'
 import { BaseFilter } from './BaseFilter'
 

--- a/packages/searchkit-sdk/src/filters/NumericRangeFilter.ts
+++ b/packages/searchkit-sdk/src/filters/NumericRangeFilter.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import isUndefined from 'lodash/isUndefined'
 import { RangeFilter } from '../core/QueryManager'
 import { BaseFilter } from './BaseFilter'
 
@@ -21,8 +21,8 @@ class NumericRangeFilter implements BaseFilter {
 
   getFilters(filters: Array<RangeFilter>) {
     const rangeFilter: { gte?: number; lte?: number } = {}
-    if (!_.isUndefined(filters[0].min)) rangeFilter.gte = filters[0].min
-    if (!_.isUndefined(filters[0].max)) rangeFilter.lte = filters[0].max
+    if (!isUndefined(filters[0].min)) rangeFilter.gte = filters[0].min
+    if (!isUndefined(filters[0].max)) rangeFilter.lte = filters[0].max
     return { range: { [this.config.field]: rangeFilter } }
   }
 


### PR DESCRIPTION
This changes lodash imports to direct import statements and helps projects using searchkit to reduce their bundle size.

Importing as whole like `import _ from 'lodash'` can lead to large bundle sizes, because tree shaking is not possible.