### PR TITLE
Embedding videos for searchkit-elastic-ui.mdx

### DIFF
--- a/docs/docs/searchkit-elastic-ui.mdx
+++ b/docs/docs/searchkit-elastic-ui.mdx
@@ -5,6 +5,9 @@ sidebar_label: "@searchkit/elastic-ui"
 slug: /reference/searchkit-elastic-ui
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+export const videoStyling = {'maxHeight': '350px', 'maxWidth': '100%'}
+
 ## Setup
 
 Require to setup the provider, define a GQL query for components and use the searchkitQuery hook to perform the search. See Quick start UI Setup for more information.
@@ -94,7 +97,7 @@ export default () => {
 
 ### SearchBar
 
-searchbar.mov
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/Searchbar.mov")} />
 
 #### Usage
 
@@ -115,7 +118,8 @@ import {
 
 
 ### SelectedFilters
-SelectedFilters.mov
+
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/SelectedFilters.mov")} />
 
 #### Usage
 
@@ -138,7 +142,7 @@ import {
 
 ### ResetSearchButton
 
-ResetSearchButton.mov
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/ResetSearchButton.mov")} />
 
 #### Usage
 
@@ -159,7 +163,8 @@ import {
 
 
 ### Pagination
-Pagination.mov
+
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/Pagination.mov")} />
 
 #### Usage
 
@@ -246,13 +251,17 @@ export default () => {
 ```
 
 ### ListFacet
-ListFacet.mov
+
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/ListFacet.mov")} />
 
 ### RangeSliderFacet
-RangeSliderFacet.mov
+
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/RangeSliderFacet.mov")} />
 
 ### ComboBoxFacet
-ComboBoxFacet.mov
+
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/ComboBoxFacet.mov")} />
 
 ### DateRangeFacet
-DateRangeFilter.mov
+
+<video className="mx-auto" style={videoStyling} autoPlay muted loop src={useBaseUrl("movs/DateRangeFilter.mov")} />


### PR DESCRIPTION
Just adding actual video instead of references for better experience. Renamed .md => .mdx for better default syntax highlighting.
![2022-04-14_17-21](https://user-images.githubusercontent.com/20042822/163410567-7cf417e4-0f1d-49f5-8715-3f4456f8c72f.png)

