### PR TITLE
Searchkit Suggestors support 

### DIFF
--- a/docs/docs/searchkit-sdk-autocomplete.mdx
+++ b/docs/docs/searchkit-sdk-autocomplete.mdx
@@ -1,0 +1,146 @@
+---
+id: searchkit-sdk-autocomplete
+title: Query Autocomplete
+sidebar_label: Query Autocomplete
+slug: /core/reference/searchkit-sdk/query-autocomplete
+---
+
+The autocomplete is a type of search that returns a list of results that match the query. These suggestors help you quickly build an autocomplete.
+
+## Completion Suggestor
+
+### Usage
+
+```javascript
+import Searchkit, {CompletionSuggester} from '@searchkit/sdk';
+
+const request = Searchkit({
+  host: 'http://localhost:9200',
+  index: 'test',
+  suggestions: [
+    new CompletionSuggester({
+      index: 'popular-queries',
+      identifier: 'completion',
+      field: 'suggestions',
+    }),
+  ],
+});
+
+const results = await request.executeSuggestions('swe');
+```
+
+will give back an example response of the following:
+
+```json
+[
+  {
+    "identifier": "completion",
+    "suggestions": ["Sweatpants", "Sweats", "Swimwear"]
+  }
+]
+```
+
+### Field Mapping
+
+The field that is used for the suggestions is mapped to the `suggestions` field in the index. Behind the scenes, its using the `completion` suggester. Read more [information about its capability](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#completion-suggester)
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "suggestions": {
+        "type": "completion"
+      }
+    }
+  }
+}
+```
+
+#### Options
+
+| Option | Description |
+| :-- | :-- |
+| identifier | Required. |
+| index | Optional. Used if the suggestions are contained within a different index. Overrides the main `index` option. |
+| field | Required. String. field that is of type `completion`. Used for suggesting terms |
+| size | Optional. Number. number of suggestions to return. Default is 5 |
+| skip_duplicates | Optional. Boolean. Whether to skip duplicate suggestions. Default is true |
+
+## Hits Suggestor
+
+Will return a list of hits that match the query. In this example we are using the `Prefix Query` which uses a multi-match `bool_prefix` type. The hits suggestor is used to return a list of hits that match the query.
+
+In this example, `title_suggest` is a `search_as_you_type` field. [Read more about it](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#search-as-you-type).
+
+### Usage
+
+```javascript
+import Searchkit, {HitsSuggestor, PrefixQuery} from '@searchkit/sdk';
+
+const request = Searchkit({
+  host: 'http://localhost:9200',
+  index: 'test',
+  suggestions: [
+    new HitsSuggestor({
+      index: 'mrp-products',
+      identifier: 'hits',
+      hits: {
+        fields: ['name', 'designerName'],
+        highlightedFields: ['name', 'designerName'],
+      },
+      query: new PrefixQuery({
+        fields: ['title_suggest'],
+      }),
+    }),
+  ],
+});
+
+const results = await request.executeSuggestions('shi');
+```
+
+Will get a response like
+
+```json
+[
+  {
+    "identifier": "hits",
+    "hits": [
+      {
+        "fields": {
+          "designerName": "GUCCI",
+          "name": "Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo Shirt"
+        },
+        "highlight": {
+          "title_suggest._index_prefix": [
+            "GUCCI Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo <em>Shirt</em>"
+          ]
+        },
+        "id": "10163292707229244"
+      },
+      {
+        "fields": {
+          "designerName": "FEAR OF GOD",
+          "name": "Logo-Flocked Cotton-Jersey T-Shirt"
+        },
+        "highlight": {
+          "title_suggest._index_prefix": [
+            "FEAR OF GOD Logo-Flocked Cotton-Jersey T-<em>Shirt</em>"
+          ]
+        },
+        "id": "560971904241887"
+      }
+    ]
+  }
+]
+```
+
+#### Options
+
+| Option | Description |
+| :-- | :-- |
+| identifier | Required. |
+| index | Optional. Used if the suggestions are contained within a different index. Overrides the main `index` option. |
+| hits.fields | Required. Field values to bring back |
+| hits.highlightedFields | Optional. Fields to highlight |
+| query | Optional. Number. number of suggestions to return. Default is 5 |
+| skip_duplicates | Optional. Boolean. Whether to skip duplicate suggestions. Default is true |

--- a/packages/searchkit-sdk/src/query/PrefixQuery.ts
+++ b/packages/searchkit-sdk/src/query/PrefixQuery.ts
@@ -1,0 +1,31 @@
+import QueryManager from '../core/QueryManager'
+import { Query } from '../core/RequestBodyBuilder'
+import BaseQuery from './BaseQuery'
+
+interface PrefixQueryOptions {
+  fields: string[]
+}
+
+export default class PrefixQuery implements BaseQuery {
+  private fields: string[]
+
+  constructor(options: PrefixQueryOptions) {
+    this.fields = options.fields
+  }
+
+  getFilter(queryManager: QueryManager): Query {
+    return {
+      bool: {
+        must: [
+          {
+            multi_match: {
+              query: queryManager.getQuery(),
+              type: 'bool_prefix',
+              fields: this.fields
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/searchkit-sdk/src/query/index.ts
+++ b/packages/searchkit-sdk/src/query/index.ts
@@ -1,3 +1,4 @@
 export { default as MultiMatchQuery } from './MultiMatchQuery'
 export { default as BaseQuery } from './BaseQuery'
 export { default as CustomQuery } from './CustomQuery'
+export { default as PrefixQuery } from './PrefixQuery'

--- a/packages/searchkit-sdk/src/suggestors/CompletionSuggestor.ts
+++ b/packages/searchkit-sdk/src/suggestors/CompletionSuggestor.ts
@@ -1,0 +1,55 @@
+import { SearchkitTransporter } from '../transporters'
+import { BaseSuggestor, BaseSuggestorResponse } from '.'
+
+export interface CompletionSuggesterOptions {
+  index?: string
+  identifier: string
+  field: string
+  size?: number
+  skip_duplicates?: boolean
+}
+
+export interface CompletionSuggesterResponse extends BaseSuggestorResponse {
+  identifier: string
+  suggestions: string[]
+}
+
+export class CompletionSuggester implements BaseSuggestor<CompletionSuggesterResponse> {
+  options: CompletionSuggesterOptions
+
+  constructor(options: CompletionSuggesterOptions) {
+    this.options = options
+  }
+
+  async getSuggestions(
+    query: string,
+    transport: SearchkitTransporter
+  ): Promise<CompletionSuggesterResponse> {
+    const { index, identifier, field, size = 5, skip_duplicates } = this.options
+
+    const eql = {
+      size: 0,
+      _source: [],
+      suggest: {
+        suggest: {
+          prefix: query,
+          completion: {
+            size: size,
+            skip_duplicates: !skip_duplicates,
+            field: field,
+            fuzzy: {
+              fuzziness: 1
+            }
+          }
+        }
+      }
+    }
+
+    const response = await transport.performRequest(eql, { index })
+
+    return {
+      identifier: identifier,
+      suggestions: response.suggest.suggest[0].options.map((suggestion) => suggestion.text)
+    }
+  }
+}

--- a/packages/searchkit-sdk/src/suggestors/HitsSuggestor.ts
+++ b/packages/searchkit-sdk/src/suggestors/HitsSuggestor.ts
@@ -1,0 +1,76 @@
+import { CustomHighlightConfig } from '..'
+import { BaseQuery } from '../query'
+import { SearchkitTransporter } from '../transporters'
+import QueryManager from '../core/QueryManager'
+import { SearchkitHit } from '../transformers'
+import { BaseSuggestor, BaseSuggestorResponse } from '.'
+
+export interface HitsSuggestorResponse extends BaseSuggestorResponse {
+  hits: SearchkitHit[]
+}
+
+export interface HitsSuggestorOptions {
+  index?: string
+  identifier: string
+  hits: {
+    fields: string[]
+    highlightedFields?: (string | CustomHighlightConfig)[]
+  }
+  query: BaseQuery
+  size?: number
+}
+
+export class HitsSuggestor implements BaseSuggestor<HitsSuggestorResponse> {
+  options: HitsSuggestorOptions
+
+  constructor(options: HitsSuggestorOptions) {
+    this.options = options
+  }
+
+  async getSuggestions(
+    query: string,
+    transport: SearchkitTransporter
+  ): Promise<HitsSuggestorResponse> {
+    const { index, identifier, hits, query: queryHandler, size = 5 } = this.options
+
+    const qm = new QueryManager()
+    qm.setQuery(query)
+
+    const sourceFields = {
+      _source: {
+        includes: hits.fields
+      }
+    }
+
+    let highlight
+    hits.highlightedFields?.forEach((field) => {
+      if (!highlight) {
+        highlight = { fields: {} }
+      }
+      if (typeof field == 'string') {
+        highlight.fields[field] = {}
+      } else {
+        highlight.fields[field.field] = field.config
+      }
+    })
+
+    const eql = {
+      size,
+      query: queryHandler.getFilter(qm),
+      ...sourceFields,
+      highlight
+    }
+
+    const response = await transport.performRequest(eql, { index })
+
+    return {
+      identifier,
+      hits: response.hits.hits.map((hit) => ({
+        id: hit._id,
+        fields: hit._source,
+        highlight: hit.highlight || {},
+        rawHit: hit
+      }))
+    }
+  }
+}

--- a/packages/searchkit-sdk/src/suggestors/index.ts
+++ b/packages/searchkit-sdk/src/suggestors/index.ts
@@ -1,0 +1,12 @@
+import { SearchkitTransporter } from '../transporters'
+
+export interface BaseSuggestor<T> {
+  getSuggestions: (query: string, transport: SearchkitTransporter) => Promise<T>
+}
+
+export interface BaseSuggestorResponse {
+  identifier: string
+}
+
+export * from './HitsSuggestor'
+export * from './CompletionSuggestor'

--- a/packages/searchkit-sdk/src/transporters/FetchClientTransporter.ts
+++ b/packages/searchkit-sdk/src/transporters/FetchClientTransporter.ts
@@ -1,12 +1,13 @@
 import { SearchkitConfig } from '..'
-import { SearchkitTransporter } from '.'
+import { SearchkitTransporter, SearchkitTransporterOverrides } from '.'
 
 export default class FetchClientTransporter implements SearchkitTransporter {
   constructor(private config: SearchkitConfig) {}
 
-  async performRequest(requestBody) {
+  async performRequest(requestBody, overrides: SearchkitTransporterOverrides = {}): Promise<any> {
     if (!fetch) throw new Error('Fetch is not supported in this browser / environment')
-    const response = await fetch(this.config.host + '/' + this.config.index + '/_search', {
+    const { index = this.config.index } = overrides
+    const response = await fetch(this.config.host + '/' + index + '/_search', {
       method: 'POST',
       body: JSON.stringify(requestBody),
       headers: {

--- a/packages/searchkit-sdk/src/transporters/index.ts
+++ b/packages/searchkit-sdk/src/transporters/index.ts
@@ -1,4 +1,8 @@
+export interface SearchkitTransporterOverrides {
+  index?: string
+}
+
 export interface SearchkitTransporter {
-  performRequest(requestBody): Promise<any>
+  performRequest(requestBody, overrides?: SearchkitTransporterOverrides): Promise<any>
 }
 export { default as FetchClientTransporter } from './FetchClientTransporter'

--- a/packages/searchkit-sdk/tests/__mock-data__/suggestors/Completion.json
+++ b/packages/searchkit-sdk/tests/__mock-data__/suggestors/Completion.json
@@ -1,0 +1,50 @@
+{
+  "took" : 1,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 0,
+      "relation" : "eq"
+    },
+    "max_score" : null,
+    "hits" : [ ]
+  },
+  "suggest" : {
+    "suggest" : [
+      {
+        "text" : "swe",
+        "offset" : 0,
+        "length" : 3,
+        "options" : [
+          {
+            "text" : "Sweatpants",
+            "_index" : "mrp-products",
+            "_id" : "13452677152333220",
+            "_score" : 2.0,
+            "_source" : { }
+          },
+          {
+            "text" : "Sweats",
+            "_index" : "mrp-products",
+            "_id" : "13452677152061433",
+            "_score" : 2.0,
+            "_source" : { }
+          },
+          {
+            "text" : "Swimwear",
+            "_index" : "mrp-products",
+            "_id" : "6630340699206111",
+            "_score" : 2.0,
+            "_source" : { }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/searchkit-sdk/tests/__mock-data__/suggestors/Hits.json
+++ b/packages/searchkit-sdk/tests/__mock-data__/suggestors/Hits.json
@@ -1,0 +1,89 @@
+{
+  "took" : 2,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 1085,
+      "relation" : "eq"
+    },
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "mrp-products",
+        "_id" : "10163292707229244",
+        "_score" : 1.0,
+        "_source" : {
+          "name" : "Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo Shirt",
+          "designerName" : "GUCCI"
+        },
+        "highlight" : {
+          "title_suggest._index_prefix" : [
+            "GUCCI Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo <em>Shirt</em>"
+          ]
+        }
+      },
+      {
+        "_index" : "mrp-products",
+        "_id" : "560971904241887",
+        "_score" : 1.0,
+        "_source" : {
+          "name" : "Logo-Flocked Cotton-Jersey T-Shirt",
+          "designerName" : "FEAR OF GOD"
+        },
+        "highlight" : {
+          "title_suggest._index_prefix" : [
+            "FEAR OF GOD Logo-Flocked Cotton-Jersey T-<em>Shirt</em>"
+          ]
+        }
+      },
+      {
+        "_index" : "mrp-products",
+        "_id" : "11452292647412043",
+        "_score" : 1.0,
+        "_source" : {
+          "name" : "Oversized Logo-Embroidered Printed Cotton-Jersey T-Shirt",
+          "designerName" : "VETEMENTS"
+        },
+        "highlight" : {
+          "title_suggest._index_prefix" : [
+            "VETEMENTS Oversized Logo-Embroidered Printed Cotton-Jersey T-<em>Shirt</em>"
+          ]
+        }
+      },
+      {
+        "_index" : "mrp-products",
+        "_id" : "13452677150717069",
+        "_score" : 1.0,
+        "_source" : {
+          "name" : "Cotton-Jersey T-Shirt",
+          "designerName" : "JAMES PERSE"
+        },
+        "highlight" : {
+          "title_suggest._index_prefix" : [
+            "JAMES PERSE Cotton-Jersey T-<em>Shirt</em>"
+          ]
+        }
+      },
+      {
+        "_index" : "mrp-products",
+        "_id" : "9465239339532782",
+        "_score" : 1.0,
+        "_source" : {
+          "name" : "Holman Slim-Fit Striped Sea Island Cotton Polo Shirt",
+          "designerName" : "ORLEBAR BROWN"
+        },
+        "highlight" : {
+          "title_suggest._index_prefix" : [
+            "ORLEBAR BROWN Holman Slim-Fit Striped Sea Island Cotton Polo <em>Shirt</em>"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/packages/searchkit-sdk/tests/suggestions/CompletionSuggestor.test.ts
+++ b/packages/searchkit-sdk/tests/suggestions/CompletionSuggestor.test.ts
@@ -1,0 +1,59 @@
+import nock from 'nock'
+import SearchkitRequest from '../../src'
+import { CompletionSuggester } from '../../src'
+import CompletionsMock from '../__mock-data__/suggestors/Completion.json'
+
+describe('Suggestions', () => {
+  it('Completion Suggestor', async () => {
+    const request = SearchkitRequest({
+      host: 'http://localhost:9200',
+      index: 'test',
+      suggestions: [
+        new CompletionSuggester({
+          index: 'mrp-products',
+          identifier: 'completion',
+          field: 'suggestions'
+        })
+      ]
+    })
+
+    const scope = nock('http://localhost:9200')
+      .post('/mrp-products/_search')
+      .reply(200, (uri, body) => {
+        expect(body).toMatchInlineSnapshot(`
+          Object {
+            "_source": Array [],
+            "size": 0,
+            "suggest": Object {
+              "suggest": Object {
+                "completion": Object {
+                  "field": "suggestions",
+                  "fuzzy": Object {
+                    "fuzziness": 1,
+                  },
+                  "size": 5,
+                  "skip_duplicates": true,
+                },
+                "prefix": "swe",
+              },
+            },
+          }
+        `)
+        return CompletionsMock
+      })
+
+    const results = await request.executeSuggestions('swe')
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "identifier": "completion",
+          "suggestions": Array [
+            "Sweatpants",
+            "Sweats",
+            "Swimwear",
+          ],
+        },
+      ]
+    `)
+  })
+})

--- a/packages/searchkit-sdk/tests/suggestions/HitsSuggestor.test.ts
+++ b/packages/searchkit-sdk/tests/suggestions/HitsSuggestor.test.ts
@@ -1,0 +1,208 @@
+import nock from 'nock'
+import SearchkitRequest from '../../src'
+import { HitsSuggestor, PrefixQuery } from '../../src'
+import HitsMMock from '../__mock-data__/suggestors/Hits.json'
+
+describe('Suggestions', () => {
+  it('HitsSuggestor', async () => {
+    const request = SearchkitRequest({
+      host: 'http://localhost:9200',
+      index: 'test',
+      suggestions: [
+        new HitsSuggestor({
+          index: 'mrp-products',
+          identifier: 'hits',
+          hits: {
+            fields: ['name', 'designerName'],
+            highlightedFields: ['name', 'designerName']
+          },
+          query: new PrefixQuery({
+            fields: ['title_suggest', 'title_suggest.2gram', 'title_suggest.3gram']
+          })
+        })
+      ]
+    })
+
+    const scope = nock('http://localhost:9200')
+      .post('/mrp-products/_search')
+      .reply(200, (uri, body) => {
+        expect(body).toMatchInlineSnapshot(`
+          Object {
+            "_source": Object {
+              "includes": Array [
+                "name",
+                "designerName",
+              ],
+            },
+            "highlight": Object {
+              "fields": Object {
+                "designerName": Object {},
+                "name": Object {},
+              },
+            },
+            "query": Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "multi_match": Object {
+                      "fields": Array [
+                        "title_suggest",
+                        "title_suggest.2gram",
+                        "title_suggest.3gram",
+                      ],
+                      "query": "test",
+                      "type": "bool_prefix",
+                    },
+                  },
+                ],
+              },
+            },
+            "size": 5,
+          }
+        `)
+        expect((body as Record<string, any>).size).toBe(5)
+        return HitsMMock
+      })
+
+    const results = await request.executeSuggestions('test')
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "hits": Array [
+            Object {
+              "fields": Object {
+                "designerName": "GUCCI",
+                "name": "Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo Shirt",
+              },
+              "highlight": Object {
+                "title_suggest._index_prefix": Array [
+                  "GUCCI Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo <em>Shirt</em>",
+                ],
+              },
+              "id": "10163292707229244",
+              "rawHit": Object {
+                "_id": "10163292707229244",
+                "_index": "mrp-products",
+                "_score": 1,
+                "_source": Object {
+                  "designerName": "GUCCI",
+                  "name": "Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo Shirt",
+                },
+                "highlight": Object {
+                  "title_suggest._index_prefix": Array [
+                    "GUCCI Slim-Fit Logo-Jacquard Cotton and Silk-Blend Polo <em>Shirt</em>",
+                  ],
+                },
+              },
+            },
+            Object {
+              "fields": Object {
+                "designerName": "FEAR OF GOD",
+                "name": "Logo-Flocked Cotton-Jersey T-Shirt",
+              },
+              "highlight": Object {
+                "title_suggest._index_prefix": Array [
+                  "FEAR OF GOD Logo-Flocked Cotton-Jersey T-<em>Shirt</em>",
+                ],
+              },
+              "id": "560971904241887",
+              "rawHit": Object {
+                "_id": "560971904241887",
+                "_index": "mrp-products",
+                "_score": 1,
+                "_source": Object {
+                  "designerName": "FEAR OF GOD",
+                  "name": "Logo-Flocked Cotton-Jersey T-Shirt",
+                },
+                "highlight": Object {
+                  "title_suggest._index_prefix": Array [
+                    "FEAR OF GOD Logo-Flocked Cotton-Jersey T-<em>Shirt</em>",
+                  ],
+                },
+              },
+            },
+            Object {
+              "fields": Object {
+                "designerName": "VETEMENTS",
+                "name": "Oversized Logo-Embroidered Printed Cotton-Jersey T-Shirt",
+              },
+              "highlight": Object {
+                "title_suggest._index_prefix": Array [
+                  "VETEMENTS Oversized Logo-Embroidered Printed Cotton-Jersey T-<em>Shirt</em>",
+                ],
+              },
+              "id": "11452292647412043",
+              "rawHit": Object {
+                "_id": "11452292647412043",
+                "_index": "mrp-products",
+                "_score": 1,
+                "_source": Object {
+                  "designerName": "VETEMENTS",
+                  "name": "Oversized Logo-Embroidered Printed Cotton-Jersey T-Shirt",
+                },
+                "highlight": Object {
+                  "title_suggest._index_prefix": Array [
+                    "VETEMENTS Oversized Logo-Embroidered Printed Cotton-Jersey T-<em>Shirt</em>",
+                  ],
+                },
+              },
+            },
+            Object {
+              "fields": Object {
+                "designerName": "JAMES PERSE",
+                "name": "Cotton-Jersey T-Shirt",
+              },
+              "highlight": Object {
+                "title_suggest._index_prefix": Array [
+                  "JAMES PERSE Cotton-Jersey T-<em>Shirt</em>",
+                ],
+              },
+              "id": "13452677150717069",
+              "rawHit": Object {
+                "_id": "13452677150717069",
+                "_index": "mrp-products",
+                "_score": 1,
+                "_source": Object {
+                  "designerName": "JAMES PERSE",
+                  "name": "Cotton-Jersey T-Shirt",
+                },
+                "highlight": Object {
+                  "title_suggest._index_prefix": Array [
+                    "JAMES PERSE Cotton-Jersey T-<em>Shirt</em>",
+                  ],
+                },
+              },
+            },
+            Object {
+              "fields": Object {
+                "designerName": "ORLEBAR BROWN",
+                "name": "Holman Slim-Fit Striped Sea Island Cotton Polo Shirt",
+              },
+              "highlight": Object {
+                "title_suggest._index_prefix": Array [
+                  "ORLEBAR BROWN Holman Slim-Fit Striped Sea Island Cotton Polo <em>Shirt</em>",
+                ],
+              },
+              "id": "9465239339532782",
+              "rawHit": Object {
+                "_id": "9465239339532782",
+                "_index": "mrp-products",
+                "_score": 1,
+                "_source": Object {
+                  "designerName": "ORLEBAR BROWN",
+                  "name": "Holman Slim-Fit Striped Sea Island Cotton Polo Shirt",
+                },
+                "highlight": Object {
+                  "title_suggest._index_prefix": Array [
+                    "ORLEBAR BROWN Holman Slim-Fit Striped Sea Island Cotton Polo <em>Shirt</em>",
+                  ],
+                },
+              },
+            },
+          ],
+          "identifier": "hits",
+        },
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
This feature will enable building components for autocomplete features within searchkit. First step is to enable SDK to configure and perform getting suggestions.