### PR TITLE
Cloud id support

### DIFF
--- a/docs/docs/searchkit-sdk-core.mdx
+++ b/docs/docs/searchkit-sdk-core.mdx
@@ -88,6 +88,31 @@ const response = await request
 
 You can configure & connect to an Elasticsearch instance without any credentials although its strongly suggested that you do if you're using the SDK within the browser. Below are some of the options you can use to secure the connection between you and Elasticsearch.
 
+### Elasticsearch via Elastic Cloud
+
+When your elasticsearch instance is hosted on [cloud.elastic.co](https://cloud.elastic.co), you can use the `cloudId` to connect to it.
+
+```javascript
+
+const searchkitConfig = {
+  cloud: {
+    id: 'commerce-demo:dXMtZWFzdDQuZ2NwLmVsYXN0aWMtY2xvdWQuY29tOjQ0MyRkMWJkMzY4NjJjZTU0YzdiOTAzZTJhYWNkNGNkN2YwYSQ2ZDRiY2YwOWI2ZWU0NjBjOWVlNTg4YjJiNWM5ZGE0MQ==', // elastic cloud id
+  },
+  connectionOptions: {
+    apiKey: "<api-key>"
+  },
+  index: 'movies',
+  hits: { fields: [ 'title', 'plot', 'poster' ] },
+  query: new MultiMatchQuery({
+    fields: [ 'plot','title^4'],
+    highlightFields: ["title"]
+  })
+}
+
+const request = Searchkit(config) const response = await request .query("heat")
+
+```
+
 ### Proxy the search call through your API
 
 If you're using Searchkit SDK directly within the browser and require Elasticsearch to be accesible from the browser, opening up a route on your API that proxies the request through your API could be an option. This means that we are not exposing Elasticsearch on the internet and gives you opportunity to add additional filters to the Elasticsearch query.

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -35,7 +35,7 @@
     "@graphql-codegen/typescript": "1.15.0",
     "@graphql-codegen/typescript-operations": "1.15.0",
     "@graphql-codegen/typescript-react-apollo": "1.15.0",
-    "@types/node": "^13.9.1",
+    "@types/node": "^18.0.0",
     "@types/react": "^16.9.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@testing-library/react": "^11.1.2",
     "@types/elasticsearch": "^5.0.36",
     "@types/jest": "^26.0.15",
-    "@types/node": "^13.9.1",
+    "@types/node": "^18.0.0",
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.0.1",

--- a/packages/searchkit-cli/package.json
+++ b/packages/searchkit-cli/package.json
@@ -36,7 +36,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@types/node": "^13.9.1",
+    "@types/node": "^18.0.0",
     "typescript": "^4.0.5"
   }
 }

--- a/packages/searchkit-client/package.json
+++ b/packages/searchkit-client/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@apollo/client": "^3.3.19",
     "@testing-library/react-hooks": "^3.4.2",
-    "@types/node": "^13.9.1",
+    "@types/node": "^18.0.0",
     "@types/react": "^17.0.13",
     "graphql": "^15.5.0",
     "husky": "^3.0.8",

--- a/packages/searchkit-schema/package.json
+++ b/packages/searchkit-schema/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@types/node": "^13.9.1",
+    "@types/node": "^18.0.0",
     "apollo-server-micro": "^2.19.0",
     "express": "^4.17.1",
     "nock": "^13.0.5",

--- a/packages/searchkit-sdk/package.json
+++ b/packages/searchkit-sdk/package.json
@@ -40,7 +40,7 @@
     "@elastic/elasticsearch": "*"
   },
   "devDependencies": {
-    "@types/node": "^13.9.1",
+    "@types/node": "^18.0.0",
     "cross-fetch": "^3.1.5",
     "nock": "^13.0.5",
     "react": "^17.0.2",

--- a/packages/searchkit-sdk/src/index.ts
+++ b/packages/searchkit-sdk/src/index.ts
@@ -34,8 +34,13 @@ export interface CustomHighlightConfig {
   config: any
 }
 
+export interface CloudHost {
+  id: string
+}
+
 export interface BaseConfig {
-  host: string
+  host?: string
+  cloud?: CloudHost
   index: string
   connectionOptions?: {
     apiKey?: string

--- a/packages/searchkit-sdk/src/transporters/ESClientTransporter.ts
+++ b/packages/searchkit-sdk/src/transporters/ESClientTransporter.ts
@@ -1,4 +1,4 @@
-import { Client, ClientOptions } from '@elastic/elasticsearch'
+import { Client } from '@elastic/elasticsearch'
 import HttpAgent, { HttpsAgent } from 'agentkeepalive'
 import { SearchkitConfig } from '..'
 import type { SearchkitTransporter } from '.'
@@ -14,7 +14,7 @@ export default class ESClientTransporter implements SearchkitTransporter {
       throw new Error('Host or cloud is required')
     }
 
-    const esClientConfig: ClientOptions = {
+    const esClientConfig: any = {
       ...(this.config.host ? { node: this.config.host } : { cloud: { id: this.config.cloud.id } }),
       auth: {
         apiKey: this.config.connectionOptions?.apiKey

--- a/packages/searchkit-sdk/src/transporters/FetchClientTransporter.ts
+++ b/packages/searchkit-sdk/src/transporters/FetchClientTransporter.ts
@@ -1,13 +1,29 @@
+import { RequestBody } from '@elastic/elasticsearch-types'
 import { SearchkitConfig } from '..'
+import { getHostFromCloud } from './utils'
 import { SearchkitTransporter, SearchkitTransporterOverrides } from '.'
 
 export default class FetchClientTransporter implements SearchkitTransporter {
   constructor(private config: SearchkitConfig) {}
 
-  async performRequest(requestBody, overrides: SearchkitTransporterOverrides = {}): Promise<any> {
+  async performRequest(
+    requestBody: RequestBody,
+    overrides: SearchkitTransporterOverrides = {}
+  ): Promise<any> {
     if (!fetch) throw new Error('Fetch is not supported in this browser / environment')
+
+    if (!this.config.host && !this.config.cloud) {
+      throw new Error('Host or cloud is required')
+    }
+
+    let host = this.config.host
+
+    if (this.config.cloud) {
+      host = getHostFromCloud(this.config.cloud)
+    }
+
     const { index = this.config.index } = overrides
-    const response = await fetch(this.config.host + '/' + index + '/_search', {
+    const response = await fetch(host + '/' + index + '/_search', {
       method: 'POST',
       body: JSON.stringify(requestBody),
       headers: {

--- a/packages/searchkit-sdk/src/transporters/__tests__/ESClientTransporter.test.ts
+++ b/packages/searchkit-sdk/src/transporters/__tests__/ESClientTransporter.test.ts
@@ -54,4 +54,58 @@ describe('ESClientTransporter', () => {
         expect(response.hits.hits[0]._source.title).toEqual('My title')
       })
   })
+
+  it('perform a request with cloudId', () => {
+    const transporter = new ESClientTransporter({
+      cloud: {
+        id: 'commerce-demo:dXMtZWFzdDQuZ2NwLmVsYXN0aWMtY2xvdWQuY29tOjQ0MyRkMWJkMzY4NjJjZTU0YzdiOTAzZTJhYWNkNGNkN2YwYSQ2ZDRiY2YwOWI2ZWU0NjBjOWVlNTg4YjJiNWM5ZGE0MQ=='
+      },
+      index: 'my_index',
+      connectionOptions: {
+        apiKey: 'blah',
+        headers: {
+          'X-Custom-Header': 'blah'
+        }
+      },
+      hits: {
+        fields: []
+      }
+    })
+
+    const body = {
+      query: {
+        match_all: {}
+      }
+    }
+
+    const scope = nock('https://d1bd36862ce54c7b903e2aacd4cd7f0a.us-east4.gcp.elastic-cloud.com', {
+      reqheaders: {
+        'authorization': 'ApiKey blah',
+        'X-Custom-Header': 'blah'
+      }
+    })
+      .post('/my_index/_search')
+      .reply(200, () => ({
+        hits: {
+          hits: [
+            {
+              _id: '1',
+              _source: {
+                title: 'My title'
+              }
+            }
+          ]
+        }
+      }))
+
+    return transporter
+      .performRequest({
+        body
+      })
+      .then((response) => {
+        expect(response.hits.hits).toHaveLength(1)
+        expect(response.hits.hits[0]._id).toEqual('1')
+        expect(response.hits.hits[0]._source.title).toEqual('My title')
+      })
+  })
 })

--- a/packages/searchkit-sdk/src/transporters/__tests__/FetchClientTransporter.test.ts
+++ b/packages/searchkit-sdk/src/transporters/__tests__/FetchClientTransporter.test.ts
@@ -53,4 +53,76 @@ describe('FetchClientTransporter', () => {
         expect(response.hits.hits[0]._source.title).toEqual('My title')
       })
   })
+
+  it('perform a request with cloudid', () => {
+    const transporter = new FetchClientTransporter({
+      cloud: {
+        id: 'commerce-demo:dXMtZWFzdDQuZ2NwLmVsYXN0aWMtY2xvdWQuY29tOjQ0MyRkMWJkMzY4NjJjZTU0YzdiOTAzZTJhYWNkNGNkN2YwYSQ2ZDRiY2YwOWI2ZWU0NjBjOWVlNTg4YjJiNWM5ZGE0MQ=='
+      },
+      index: 'my_index',
+      connectionOptions: {
+        apiKey: 'blah',
+        headers: {
+          'X-Custom-Header': 'blah'
+        }
+      },
+      hits: {
+        fields: []
+      }
+    })
+
+    const body = {
+      query: {
+        match_all: {}
+      }
+    }
+
+    const scope = nock('https://d1bd36862ce54c7b903e2aacd4cd7f0a.us-east4.gcp.elastic-cloud.com', {
+      reqheaders: {
+        'authorization': 'ApiKey blah',
+        'X-Custom-Header': 'blah'
+      }
+    })
+      .post('/my_index/_search')
+      .reply(200, () => ({
+        hits: {
+          hits: [
+            {
+              _id: '1',
+              _source: {
+                title: 'My title'
+              }
+            }
+          ]
+        }
+      }))
+
+    return transporter
+      .performRequest({
+        body
+      })
+      .then((response) => {
+        expect(response.hits.hits).toHaveLength(1)
+        expect(response.hits.hits[0]._id).toEqual('1')
+        expect(response.hits.hits[0]._source.title).toEqual('My title')
+      })
+  })
+
+  it('throws an error when host or cloud id not specified', () => {
+    const transporter = new FetchClientTransporter({
+      index: 'my_index',
+      connectionOptions: {
+        apiKey: 'blah',
+        headers: {
+          'X-Custom-Header': 'blah'
+        }
+      },
+      hits: {
+        fields: []
+      }
+    })
+
+    // eslint-disable-next-line jest/valid-expect
+    expect(() => transporter.performRequest({})).rejects.toThrowError('Host or cloud is required')
+  })
 })

--- a/packages/searchkit-sdk/src/transporters/utils.ts
+++ b/packages/searchkit-sdk/src/transporters/utils.ts
@@ -1,0 +1,10 @@
+import { CloudHost } from '..'
+
+export function getHostFromCloud(cloud: CloudHost): string {
+  const { id } = cloud
+  // the cloud id is `cluster-name:base64encodedurl`
+  // the url is a string divided by two '$', the first is the cloud url
+  // the second the elasticsearch instance, the third the kibana instance
+  const cloudUrls = atob(id.split(':')[1]).split('$')
+  return `https://${cloudUrls[1]}.${cloudUrls[0]}`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,10 +3018,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/node@^13.9.1":
-  version "13.13.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
-  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
+"@types/node@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
+  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
When your elasticsearch instance is hosted on [cloud.elastic.co](https://cloud.elastic.co), you can use the `cloudId` to connect to it.

```javascript

const searchkitConfig = {
  cloud: {
    id: 'commerce-demo:dXMtZWFzdDQuZ2NwLmVsYXN0aWMtY2xvdWQuY29tOjQ0MyRkMWJkMzY4NjJjZTU0YzdiOTAzZTJhYWNkNGNkN2YwYSQ2ZDRiY2YwOWI2ZWU0NjBjOWVlNTg4YjJiNWM5ZGE0MQ==', // elastic cloud id
  },
  connectionOptions: {
    apiKey: "<api-key>"
  },
  index: 'movies',
  hits: { fields: [ 'title', 'plot', 'poster' ] },
  query: new MultiMatchQuery({
    fields: [ 'plot','title^4'],
    highlightFields: ["title"]
  })
}

const request = Searchkit(config) 
const response = await request 
  .query("heat")

```