### PR TITLE
Use type keyword for TS type imports

### DIFF
--- a/packages/searchkit-schema/src/resolvers/ResultsResolver.ts
+++ b/packages/searchkit-schema/src/resolvers/ResultsResolver.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-useless-catch */
 import createInstance, { SearchkitConfig, SearchkitRequest } from '@searchkit/sdk'
-import { SearchkitResponse } from '@searchkit/sdk'
+import type { SearchkitResponse } from '@searchkit/sdk'
 import ESClientTransporter from '@searchkit/sdk/lib/cjs/transporters/ESClientTransporter'
 import DataLoader from 'dataloader'
 

--- a/packages/searchkit-sdk/src/index.ts
+++ b/packages/searchkit-sdk/src/index.ts
@@ -1,5 +1,6 @@
 import type { SearchInnerHits, SearchRequest } from '@elastic/elasticsearch-types/lib/api/types'
-import QueryManager, { MixedFilter, QueryOptions } from './core/QueryManager'
+import QueryManager from './core/QueryManager'
+import type { MixedFilter, QueryOptions } from './core/QueryManager'
 import RequestBodyBuilder from './core/RequestBodyBuilder'
 import BaseQuery from './query/BaseQuery'
 import { BaseFacet } from './facets/BaseFacet'
@@ -7,12 +8,8 @@ import { BaseFilter } from './filters/BaseFilter'
 import { VisibleWhenRuleSet } from './facets'
 import { SearchkitTransporter, FetchClientTransporter } from './transporters'
 import { getAggregationsFromFacets } from './core/FacetsFns'
-import {
-  SearchkitResponseTransformer,
-  ElasticSearchResponseTransformer,
-  SearchkitResponse,
-  SearchkitHit
-} from './transformers'
+import type { SearchkitResponseTransformer, SearchkitResponse, SearchkitHit } from './transformers'
+import { ElasticSearchResponseTransformer } from './transformers'
 import { BaseSuggestor } from './suggestors'
 
 export * from './query'


### PR DESCRIPTION
Building a project using Searchkit with vite/rollup, I encountered the following errors and my project failed to build:

```
Non-existent export 'MixedFilter' is imported from node_modules/@searchkit/sdk/src/core/QueryManager.ts
Non-existent export 'QueryOptions' is imported from node_modules/@searchkit/sdk/src/core/QueryManager.ts
Non-existent export 'SearchkitResponse' is imported from node_modules/@searchkit/sdk/src/transformers/index.ts
Non-existent export 'SearchkitHit' is imported from node_modules/@searchkit/sdk/src/transformers/index.ts
```

I noticed all of these imports are actually type/interface imports, so I changed these imports to use the `type` keyword to indicate this.