### PR TITLE
V4: beforeSearch / afterSearch Hooks support

### DIFF
--- a/.changeset/wise-snakes-double.md
+++ b/.changeset/wise-snakes-double.md
@@ -1,0 +1,5 @@
+---
+'@searchkit/api': patch
+---
+
+Add beforeSearch & afterSearch hook to transform requests

--- a/apps/web/pages/docs/api-documentation/api.mdx
+++ b/apps/web/pages/docs/api-documentation/api.mdx
@@ -218,6 +218,18 @@ export default async function handler(
 }
 ```
 
+#### Parameters
+
+The `handleRequest` function takes in the following parameters:
+
+- **body** - The request body containing the search requests.
+- **options** - The options object containing the following properties:
+  - **getQuery** - The function used to override the default Elasticsearch query.
+  - **getBaseFilters** - The function used to provide the base Elasticsearch filters. These filters are applied to all search requests.
+  - **hooks** - The hooks object containing the following properties:
+    - **beforeSearch** - The function that is invoked before the search request is executed.
+    - **afterSearch** - The function that is invoked after the search response is received.  
+
 #### `getQuery` optional function
 
 The `getQuery` function is used to override the default Elasticsearch query. The function must return an Elasticsearch query. You can read more about the Elasticsearch query DSL [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
@@ -275,6 +287,93 @@ To see the full Elasticsearch query that is executed to Elasticsearch, you can r
     }
   });
 ```
+
+### Hooks
+
+Hooks are functions that are invoked at different stages of the search request. Hooks are useful if you want to perform some action before or after the search request is executed.
+
+#### `beforeSearch` hook function
+
+The `beforeSearch` hook is invoked before the search request is executed. This hook is useful if you want to perform some action before the search request is executed.
+
+Examples include:
+- Learn to rank
+- Semantic search
+- A/B testing
+
+Below is an example of a `beforeSearch` hook that adds a `rescore` query to the Elasticsearch query.
+
+To see the full Elasticsearch query that is executed to Elasticsearch, you can run the client in debug mode (see below).
+
+```ts
+  const results = await client.handleRequest(req.body, {
+    hooks: {
+      beforeSearch: (searchRequests) => {
+        const uiRequest = searchRequests[0]
+
+        return [
+          {
+            ...uiRequest,
+            rescore: {
+              window_size: 100,
+              query: {
+                rescore_query: {
+                  match: {
+                    plot: {
+                      query: uiRequest.query,
+                      operator: "and",
+                    },
+                  },
+                },
+                query_weight: 1,
+                rescore_query_weight: 10,
+              }
+            }
+          },
+          searchRequests.slice(1, searchRequests.length)
+        ]
+        
+      },
+    }
+  });
+```
+
+##### Function Parameters
+
+- **searchRequests** - An array of `SearchRequest` objects. Each `SearchRequest` object contains the following properties:
+  - **indexName** - The Elasticsearch index name.
+  - **body** - The Elasticsearch request body query.
+  - **request** - The state requested from the UI. Contains attributes like query, filters, sort, size and more.
+
+#### `afterSearch` hook function
+
+The `afterSearch` hook is invoked after the search response is received. This hook is useful if you want to perform some action after the search response is received.
+
+Examples include:
+- Logging
+- Analytics
+
+Below is an example of an `afterSearch` hook that logs the search response to the console.
+
+```ts
+  const results = await client.handleRequest(req.body, {
+    hooks: {
+      afterSearch: (searchRequests, searchResponses) => {
+        console.log(searchResponses);
+        return searchResponses;
+      },
+    },
+  });
+```
+
+##### Function Parameters
+
+- **searchRequests** - An array of `SearchRequest` objects. Each `SearchRequest` object contains the following properties:
+  - **indexName** - The Elasticsearch index name.
+  - **body** - The Elasticsearch request body query.
+  - **request** - The state requested from the UI. Contains attributes like query, filters, sort, size and more.
+  
+- **searchResponse** - The search responses array which is used to render the search results UI.
 
 ### Debug mode
 

--- a/apps/web/pages/docs/guides/_meta.json
+++ b/apps/web/pages/docs/guides/_meta.json
@@ -3,7 +3,7 @@
   "setting-up-elasticsearch": "Setting up Elasticsearch",
   "query-rules": "Query Rules",
   "user-restricted-data": "User-restricted access to data",
-  "learning-to-rank": "Learning to Rank",
+  "learn-to-rank": "Learn to Rank",
   "applying-filters": "Applying Filters",
   "customising-query": "Customising the Query",
   "facets": "Configuring Facets"

--- a/apps/web/pages/docs/guides/_meta.json
+++ b/apps/web/pages/docs/guides/_meta.json
@@ -1,8 +1,9 @@
 {
   "connecting-to-elasticsearch": "Connecting to Elasticsearch",
   "setting-up-elasticsearch": "Setting up Elasticsearch",
-  "user-restricted-data": "User-restricted access to data",
   "query-rules": "Query Rules",
+  "user-restricted-data": "User-restricted access to data",
+  "learning-to-rank": "Learning to Rank",
   "applying-filters": "Applying Filters",
   "customising-query": "Customising the Query",
   "facets": "Configuring Facets"

--- a/apps/web/pages/docs/guides/customising-query.mdx
+++ b/apps/web/pages/docs/guides/customising-query.mdx
@@ -26,6 +26,80 @@ You can also use the hooks to customise the query. For example, to add a rescore
 
 Read more about [hooks](/docs/api-documentation/api#Hooks) in api-documentation.
 
+### Example of adding a rescore query
+
+```ts
+  const results = await client.handleRequest(req.body, {
+    hooks: {
+      beforeSearch: (searchRequests) => {
+        const uiRequest = searchRequests[0]
+
+        return [
+          {
+            ...uiRequest,
+            body: {
+              ...uiRequest.body,
+              rescore: {
+                window_size: 100,
+                query: {
+                  rescore_query: {
+                    match: {
+                      plot: {
+                        query: uiRequest.body.query,
+                        operator: "and",
+                      },
+                    },
+                  },
+                  query_weight: 1,
+                  rescore_query_weight: 10,
+                }
+              }
+            }
+          },
+          searchRequests.slice(1, searchRequests.length)
+        ]
+        
+      },
+    }
+  });
+```
+
+### Example of doing a KNN search
+
+An example of extending the query to do a hybrid search with KNN search and text search. Retrieves the search query provided in the UI and uses it to retrieve an image embedding from a custom image search API. Then extends the query to do a hybrid search with KNN search (with embedding) and text search. 
+
+```ts
+  const results = await client.handleRequest(req.body, {
+    hooks: {
+      beforeSearch: async (searchRequests) => {
+        const [uiRequest, ...restRequests] = searchRequests
+
+        // get an image embedding from the query text
+        const imageEmbedding = await getImageEmbeddingFromQueryText(uiRequest.params.query)
+
+        // extends the query to do a hybrid search with KNN search and text search
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html
+        return [
+          {
+            ...uiRequest,
+            body: {
+              ...uiRequest.body,
+              "knn": {
+                "field": "image-vector",
+                "query_vector": imageEmbedding,
+                "k": 10,
+                "num_candidates": 100
+              },
+            },
+          },
+          restRequests,
+        ];
+        
+      },
+    }
+  });
+```
+
 ```ts
   const results = await client.handleRequest(req.body, {
     hooks: {

--- a/apps/web/pages/docs/guides/customising-query.mdx
+++ b/apps/web/pages/docs/guides/customising-query.mdx
@@ -21,3 +21,41 @@ const results = await apiClient.handleRequest(req.body, {
   },
 });
 ```
+
+You can also use the hooks to customise the query. For example, to add a rescore query to the default query.
+
+Read more about [hooks](/docs/api-documentation/api#Hooks) in api-documentation.
+
+```ts
+  const results = await client.handleRequest(req.body, {
+    hooks: {
+      beforeSearch: (searchRequests) => {
+        const uiRequest = searchRequests[0]
+
+        return [
+          {
+            ...uiRequest,
+            rescore: {
+              window_size: 100,
+              query: {
+                rescore_query: {
+                  match: {
+                    plot: {
+                      query: uiRequest.query,
+                      operator: "and",
+                    },
+                  },
+                },
+                query_weight: 1,
+                rescore_query_weight: 10,
+              }
+            }
+          },
+          searchRequests.slice(1, searchRequests.length)
+        ]
+        
+      },
+    }
+  });
+```
+

--- a/apps/web/pages/docs/guides/learn-to-rank.mdx
+++ b/apps/web/pages/docs/guides/learn-to-rank.mdx
@@ -1,0 +1,125 @@
+---
+title: Learn to Rank
+description: Integrate Learn to Rank with Metarank
+---
+
+# Learn to Rank
+
+Learn to Rank is a machine learning technique that allows you to train a model to rank search results. The model is trained using a set of features and a set of relevance judgements. The model is then used to rank search results.
+
+In this guide, you will learn how to integrate Learn to Rank with Metarank and Searchkit. You can learn more about Learn to Rank with Metarank in the [Metarank documentation](https://metarank.io/docs/learn-to-rank).
+
+We assume in this guide that you have:
+- Installed Metarank and Searchkit
+- Trained a model using Metarank
+- Setup the features and relevance judgements for your model
+
+## Changes to Searchkit UI
+
+Metarank requires session id and user id to be sent with each search request. One way to do this is in the `@searchkit/instantsearch-client` and provide the session id and user id via headers:
+
+```js
+const searchClient = Client({
+  url: "/api/search",
+  headers: {
+    "x-session-id": "my-session-id",
+    "x-user-id": "my-user-id",
+  },
+});
+```
+
+## Changes to the Searchkit API
+
+To integrate Learn to Rank with Searchkit, we will use the hooks for `beforeSearch` and `afterSearch`. These hooks allow us to modify the query and the results before they are sent to Elasticsearch and returned to the UI.
+
+We will use the `afterSearch` hook to send the results to the Metarank API and update the results with the new order.
+
+```ts
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+
+  const headers = req.headers
+  
+  const results = await client.handleRequest(req.body, {
+    hooks: {
+      afterSearch: async (searchRequests, searchResponses) => {
+        // Get the first search request
+        const [uiRequest, otherRequests] = searchRequests;
+        // Get the first search response
+        const [uiResponse, otherResponses] = searchResponses;
+
+        // Get the session id and user id from the headers
+        const sessionId = headers["x-session-id"];
+        const userId = headers["x-user-id"];
+
+        // Get the query from the first search request
+        const query = uiRequest.body.query;
+
+        // Get the results from the first search response
+        const results = uiResponse.body.hits.hits;
+
+
+        // Send the request to the Metarank API
+        const response = await fetch("http://localhost:8080/rank/xgboost", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            session: sessionId,
+            user: userId,
+            fields: [ 
+              { name: "query", value: query }
+            ],
+            timestamp: (new Date()).getTime(),
+            items: results.map((item) => {
+              return {
+                id: item._id,
+                // an optional array of extra fields that you can use in your model
+                fields: [
+                  { name: "title", value: item._source.title },
+                  { name: "description", value: item._source.description },
+                  { name: "url", value: item._source.url },
+                ],
+              };
+            }})
+          }),
+        });
+
+        // Get the response from the Metarank API
+        const metarankResponse = await response.json();
+
+        // Get the items order from the response
+        const items = metarankResponse.items;
+
+        // Update the order of the results for the first 20 results
+        const updatedResults = items.map((item) => {
+          const result = results.find((result) => result._id === item.id);
+          return result
+        });
+
+        // Update the results in the first search response
+        const updatedUiResponse = {
+          ...uiResponse,
+          body: {
+            ...uiResponse.body,
+            hits: {
+              ...uiResponse.body.hits,
+              hits: updatedResults,
+            },
+          },
+        };
+
+        return [
+          updatedUiResponse,
+          ...otherResponses
+        ];
+      }
+    }
+  });
+
+}
+```
+
+
+
+

--- a/apps/web/pages/index.mdx
+++ b/apps/web/pages/index.mdx
@@ -25,7 +25,7 @@ import { Tabs, Tab } from '../components/Tabs';
 
 </div>
 
-<FeatureBreakout title="Full power of Elasticsearch" description="Searchkit is built on top of Elasticsearch, which means you can use the Elasticsearch query language to build your search experience." linkTitle="Extend Query" linkHref="/docs/api-documentation/api#hooks" />
+<FeatureBreakout title="Full power of Elasticsearch" description="Searchkit is built on top of Elasticsearch, which means you can use the Elasticsearch query language to build your search experience." linkTitle="Query Hooks" linkHref="/docs/api-documentation/api#hooks" />
 <FeatureBreakout title="Open source and free to use" description="Searchkit is open source, which means you can use it for free and contribute to the project. It's battle tested and used in production by many companies." linkTitle="Searchkit on Github" linkHref="https://github.com/searchkit/searchkit" />
 <FeatureBreakout title="Algolia Instantsearch Compatible" description="Searchkit uses instantsearch, which means you can use the instantsearch libraries to build your search experience." linkTitle="Instantsearch.js Example" linkHref="/docs/examples/instantsearch-js-template" subtext="Components for React, Vue, Angular and Javascript. Build a search UI without needing frontend skills." />
 <FeatureBreakout title="Node Middleware API" description="Searchkit API is a node middleware that works between Elasticsearch and Search UI. Run it standalone or in your node API. Your choice." linkTitle="API Documentation" linkHref="/docs/api-documentation/api" />

--- a/apps/web/pages/index.mdx
+++ b/apps/web/pages/index.mdx
@@ -25,12 +25,12 @@ import { Tabs, Tab } from '../components/Tabs';
 
 </div>
 
-<FeatureBreakout title="Full power of Elasticsearch" description="Searchkit is built on top of Elasticsearch, which means you can use the Elasticsearch query language to build your search experience." linkTitle="Start Tutorial" linkHref="/docs/getting-started" />
+<FeatureBreakout title="Full power of Elasticsearch" description="Searchkit is built on top of Elasticsearch, which means you can use the Elasticsearch query language to build your search experience." linkTitle="Extend Query" linkHref="/docs/api-documentation/api#hooks" />
 <FeatureBreakout title="Open source and free to use" description="Searchkit is open source, which means you can use it for free and contribute to the project. It's battle tested and used in production by many companies." linkTitle="Searchkit on Github" linkHref="https://github.com/searchkit/searchkit" />
 <FeatureBreakout title="Algolia Instantsearch Compatible" description="Searchkit uses instantsearch, which means you can use the instantsearch libraries to build your search experience." linkTitle="Instantsearch.js Example" linkHref="/docs/examples/instantsearch-js-template" subtext="Components for React, Vue, Angular and Javascript. Build a search UI without needing frontend skills." />
 <FeatureBreakout title="Node Middleware API" description="Searchkit API is a node middleware that works between Elasticsearch and Search UI. Run it standalone or in your node API. Your choice." linkTitle="API Documentation" linkHref="/docs/api-documentation/api" />
 <FeatureBreakout title="Powerful Query Rules" description="Query rules allows you to customize the behavior of the search experience. You can use query rules to boost or filter results, or to change the ranking of results, based on a set of conditions." linkTitle="Query Rules Docs" linkHref="/docs/guides/query-rules" />
-<FeatureBreakout title="Semantic Search Capable" description="Searchkit supports the full power of Elasticsearch, which means you can use the Elasticsearch Query DSL to tune your relevance and use features like Elasticsearch semantic search." linkTitle="Customise Query Docs" linkHref="/docs/guides/customising-query"/>
+<FeatureBreakout title="Semantic Search Capable" description="Searchkit supports the full power of Elasticsearch, which means you can use the Elasticsearch Query DSL to tune your relevance and use features like Elasticsearch semantic search." linkTitle="Customise Query Docs" linkHref="/docs/guides/customising-query#example-of-doing-a-knn-search"/>
 <FeatureBreakout title="Your own Custom Query" description="Override Searchkit's Query and provide your own, tuned to your relevance needs." linkTitle="Customise Query Docs" linkHref="/docs/guides/customising-query" />
 
 ## Quick Start

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/hooks.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/hooks.test.ts.snap
@@ -1,0 +1,201 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Hooks beforeSearch & afterSearch Hooks 2`] = `
+{
+  "results": [
+    {
+      "exhaustive": {
+        "facetsCount": true,
+        "nbHits": true,
+        "typo": true,
+      },
+      "exhaustiveFacetsCount": true,
+      "exhaustiveNbHits": true,
+      "exhaustiveTypo": true,
+      "facets": {
+        "actors": {
+          "Bob Gunton": 1,
+          "Morgan Freeman": 1,
+          "Tim Robbins": 1,
+          "William Sadler": 1,
+        },
+        "rated": {
+          "R": 1,
+        },
+        "type": {
+          "movie": 1,
+        },
+      },
+      "facets_stats": {},
+      "hits": [
+        {
+          "_highlightResult": {
+            "actors": [
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Tim Robbins",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Morgan Freeman",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Bob Gunton",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "William Sadler",
+              },
+            ],
+            "title": [
+              {
+                "fullyHighlighted": false,
+                "matchLevel": "full",
+                "matchedWords": [
+                  "Shawshank",
+                ],
+                "value": "The <ais-highlight-0000000000>Shawshank</ais-highlight-0000000000> Redemption",
+              },
+            ],
+          },
+          "actors": [
+            "Tim Robbins",
+            "Morgan Freeman",
+            "Bob Gunton",
+            "William Sadler",
+          ],
+          "objectID": "tt0111161",
+          "title": "The Shawshank Redemption",
+        },
+      ],
+      "hitsPerPage": 20,
+      "index": "imdb_movies",
+      "nbHits": 1,
+      "nbPages": 1,
+      "page": 0,
+      "params": "facetFilters=&facets=*&highlightPostTag=%3C%2Fais-highlight-0000000000%3E&highlightPreTag=%3Cais-highlight-0000000000%3E&maxValuesPerFacet=10&page=0&query=shawshank&tagFilters=",
+      "processingTimeMS": 2,
+      "query": "shawshank",
+      "renderingContent": {
+        "facetOrdering": {
+          "facets": {
+            "order": [
+              "type",
+              "actors",
+              "rated",
+            ],
+          },
+          "values": {
+            "actors": {
+              "sortRemainingBy": "count",
+            },
+            "rated": {
+              "sortRemainingBy": "count",
+            },
+            "type": {
+              "sortRemainingBy": "count",
+            },
+          },
+        },
+      },
+    },
+    {
+      "exhaustive": {
+        "facetsCount": true,
+        "nbHits": true,
+        "typo": true,
+      },
+      "exhaustiveFacetsCount": true,
+      "exhaustiveNbHits": true,
+      "exhaustiveTypo": true,
+      "facets": {
+        "type": {
+          "movie": 1,
+        },
+      },
+      "facets_stats": {},
+      "hits": [
+        {
+          "_highlightResult": {
+            "actors": [
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Tim Robbins",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Morgan Freeman",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Bob Gunton",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "William Sadler",
+              },
+            ],
+            "title": [
+              {
+                "fullyHighlighted": false,
+                "matchLevel": "full",
+                "matchedWords": [
+                  "Shawshank",
+                ],
+                "value": "The <ais-highlight-0000000000>Shawshank</ais-highlight-0000000000> Redemption",
+              },
+            ],
+          },
+          "actors": [
+            "Tim Robbins",
+            "Morgan Freeman",
+            "Bob Gunton",
+            "William Sadler",
+          ],
+          "objectID": "tt0111161",
+          "title": "The Shawshank Redemption",
+        },
+      ],
+      "hitsPerPage": 1,
+      "index": "imdb_movies",
+      "nbHits": 1,
+      "nbPages": 1,
+      "page": 0,
+      "params": "analytics=false&clickAnalytics=false&facets=type&highlightPostTag=%3C%2Fais-highlight-0000000000%3E&highlightPreTag=%3Cais-highlight-0000000000%3E&hitsPerPage=1&maxValuesPerFacet=10&page=0&query=shawshank&tagFilters=",
+      "processingTimeMS": 2,
+      "query": "shawshank",
+      "renderingContent": {
+        "facetOrdering": {
+          "facets": {
+            "order": [
+              "type",
+              "actors",
+              "rated",
+            ],
+          },
+          "values": {
+            "actors": {
+              "sortRemainingBy": "count",
+            },
+            "rated": {
+              "sortRemainingBy": "count",
+            },
+            "type": {
+              "sortRemainingBy": "count",
+            },
+          },
+        },
+      },
+    },
+  ],
+}
+`;

--- a/packages/searchkit-api/src/___tests___/functional/hooks.test.ts
+++ b/packages/searchkit-api/src/___tests___/functional/hooks.test.ts
@@ -1,0 +1,76 @@
+import Client, { AlgoliaMultipleQueriesQuery, SearchRequest } from '../../'
+import nock from 'nock'
+import { DisjunctiveExampleRequest } from '../mocks/AlgoliaRequests'
+import { HitsResponseWithFacetFilter } from '../mocks/ElasticsearchResponses'
+
+const client = Client({
+  connection: {
+    host: 'https://commerce-demo.es.us-east4.gcp.elastic-cloud.com:9243',
+    apiKey: 'a2Rha1VJTUJMcGU4ajA3Tm9fZ0Y6MjAzX2pLbURTXy1hNm9SUGZGRlhJdw=='
+  },
+  search_settings: {
+    highlight_attributes: ['title', 'actors'],
+    search_attributes: ['title', 'actors', 'query'],
+    result_attributes: ['title', 'actors', 'query'],
+    facet_attributes: [
+      'type',
+      { field: 'actors.keyword', attribute: 'actors', type: 'string' },
+      'rated'
+    ]
+  }
+})
+
+describe('Hooks', () => {
+  it('beforeSearch & afterSearch Hooks', async () => {
+    nock('https://commerce-demo.es.us-east4.gcp.elastic-cloud.com:9243')
+      .post('/_msearch', (requestBody: any) => {
+        const x = JSON.parse(requestBody.split('\n')[1])
+        expect(x.knn).toMatchInlineSnapshot(`
+          {
+            "field": "query-vector",
+            "k": 10,
+            "num_candidates": 100,
+            "query_vector": [
+              -5,
+              9,
+              -12,
+            ],
+          }
+        `)
+        return true
+      })
+      .reply(200, HitsResponseWithFacetFilter)
+
+    const beforeSearchHook = jest.fn().mockImplementation(async (requests) => {
+      const uiRequest = requests[0] as SearchRequest
+
+      uiRequest.body.knn = {
+        field: 'query-vector',
+        query_vector: [-5, 9, -12],
+        k: 10,
+        num_candidates: 100
+      }
+
+      return requests
+    })
+
+    const afterSearchHook = jest.fn().mockImplementation(async (requests, responses) => {
+      return responses
+    })
+
+    const response = await client.handleInstantSearchRequests(
+      DisjunctiveExampleRequest as AlgoliaMultipleQueriesQuery[],
+      {
+        hooks: {
+          beforeSearch: beforeSearchHook,
+          afterSearch: afterSearchHook
+        }
+      }
+    )
+
+    expect(beforeSearchHook).toHaveBeenCalledTimes(1)
+    expect(afterSearchHook).toHaveBeenCalledTimes(1)
+
+    expect(response).toMatchSnapshot()
+  })
+})

--- a/packages/searchkit-api/src/types.ts
+++ b/packages/searchkit-api/src/types.ts
@@ -116,6 +116,7 @@ export interface ClientConfig {
 
 export type SearchRequest = {
   body: ElasticsearchSearchRequest
+  request: AlgoliaMultipleQueriesQuery
   indexName: string
 }
 
@@ -126,6 +127,24 @@ export interface RequestOptions {
     config: SearchSettingsConfig
   ) => ElasticsearchQuery | ElasticsearchQuery[] | undefined
   getBaseFilters?: () => ElasticsearchQuery[] | undefined
+  hooks?: {
+    /**
+     * @description Allows you to modify the search requests before they are sent to Elasticsearch
+     * @param requests An array of SearchRequest objects, each containing the body (elasticsearch query) and indexName of the request
+     * @returns An array of modified SearchRequest objects, each containing the body (elasticsearch query) and indexName of the request
+     */
+    beforeSearch?: (requests: SearchRequest[]) => Promise<SearchRequest[]>
+    /**
+     * @description Allows you to modify the search responses before its transformed into an InstantSearch response
+     * @param requests An array of SearchRequest objects, each containing the body (elasticsearch query) and indexName of the request
+     * @param responses An array of Elasticsearch Response objects
+     * @returns An array of modified Elasticsearch response objects
+     */
+    afterSearch?: (
+      requests: SearchRequest[],
+      responses: ElasticsearchResponseBody[]
+    ) => Promise<ElasticsearchResponseBody[]>
+  }
 }
 
 export interface Transporter {


### PR DESCRIPTION
Implement optional methods to allow developer to add logic to transform the elasticsearch request and the elasticsearch response. 