### PR TITLE
Query Rules: Expose rule ids in API in Search Response

### DIFF
--- a/.changeset/chilled-birds-repair.md
+++ b/.changeset/chilled-birds-repair.md
@@ -1,0 +1,5 @@
+---
+'@searchkit/api': minor
+---
+
+return appliedRules in search response

--- a/apps/web/pages/docs/guides/query-rules.mdx
+++ b/apps/web/pages/docs/guides/query-rules.mdx
@@ -300,5 +300,9 @@ Below is an example of the `QueryRewrite` action:
   }
   ```
 
+  ## Debugging Query Rules
+
+  If you are having issues with your query rules, you can find what query rules are being applied to your search request in the search response via `appliedRules`. The `appliedRules` property is an array of query rule ids that were applied to the search request. The `appliedRules` property will be empty if no query rules were applied to the search request.
+
 
 

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/filters.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/filters.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Add additional base filters to search call with one filter and query ap
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`Add additional base filters to search call with one filter and query ap
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/getFilters.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/getFilters.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Add additional base filters to search call with one filter and query ap
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`Add additional base filters to search call with one filter and query ap
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/getQuery.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/getQuery.test.ts.snap
@@ -4,6 +4,7 @@ exports[`GetQuery Extension GetQuery Extension with no matching query rules acti
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`GetQuery Extension GetQuery Extension with no matching query rules acti
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -212,6 +214,9 @@ exports[`GetQuery Extension GetQuery Extension with query rules 2`] = `
 {
   "results": [
     {
+      "appliedRules": [
+        "1",
+      ],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -313,6 +318,9 @@ exports[`GetQuery Extension GetQuery Extension with query rules 2`] = `
       },
     },
     {
+      "appliedRules": [
+        "1",
+      ],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/hitsPerPage.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/hitsPerPage.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Hits Per Page should return the default 20 for UI request 1`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`Hits Per Page should return the default 20 for UI request 1`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/hooks.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/hooks.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Hooks beforeSearch & afterSearch Hooks 2`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`Hooks beforeSearch & afterSearch Hooks 2`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/index.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/index.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Integration tests call with one filter and query applied 1`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`Integration tests call with one filter and query applied 1`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -212,6 +214,7 @@ exports[`Integration tests facets non dynamic facets 1`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -1085,6 +1088,7 @@ exports[`Integration tests facets non dynamic facets with one filter 1`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -1970,6 +1974,7 @@ exports[`Integration tests facets numeric facets 1`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -2065,6 +2070,7 @@ exports[`Integration tests facets numeric facets 1`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -2168,6 +2174,7 @@ exports[`Integration tests facets numeric filters 1`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -2226,6 +2233,7 @@ exports[`Integration tests facets numeric filters 1`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/nestedFacets.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/nestedFacets.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Nested Facets, filters and results One nested facet support 3`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -54,6 +55,7 @@ exports[`Nested Facets, filters and results One nested facet support 3`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -117,6 +119,7 @@ exports[`Nested Facets, filters and results one facet and two OR filters 3`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -167,6 +170,7 @@ exports[`Nested Facets, filters and results one facet and two OR filters 3`] = `
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -230,6 +234,7 @@ exports[`Nested Facets, filters and results one numeric facet 3`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -295,6 +300,7 @@ exports[`Nested Facets, filters and results two nested facets 3`] = `
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/queryRules.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/queryRules.test.ts.snap
@@ -4,6 +4,9 @@ exports[`Integration tests for query rules call with one filter and query applie
 {
   "results": [
     {
+      "appliedRules": [
+        "1",
+      ],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -106,6 +109,9 @@ exports[`Integration tests for query rules call with one filter and query applie
       ],
     },
     {
+      "appliedRules": [
+        "1",
+      ],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/functional/__snapshots__/relevance.test.ts.snap
+++ b/packages/searchkit-api/src/___tests___/functional/__snapshots__/relevance.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Integration tests for relevance call with one filter and query applied 
 {
   "results": [
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,
@@ -105,6 +106,7 @@ exports[`Integration tests for relevance call with one filter and query applied 
       },
     },
     {
+      "appliedRules": [],
       "exhaustive": {
         "facetsCount": true,
         "nbHits": true,

--- a/packages/searchkit-api/src/___tests___/transformRequest.test.ts
+++ b/packages/searchkit-api/src/___tests___/transformRequest.test.ts
@@ -90,7 +90,8 @@ describe('transformRequest', () => {
             facetAttributesOrder: undefined,
             pinnedDocs: [],
             userData: [],
-            touched: false
+            touched: false,
+            ruleIds: []
           }
         )
       ).toMatchInlineSnapshot(`
@@ -181,7 +182,8 @@ describe('transformRequest', () => {
           facetAttributesOrder: ['type'],
           pinnedDocs: [],
           userData: [],
-          touched: true
+          touched: true,
+          ruleIds: ['rule1']
         }
       )
     ).toMatchInlineSnapshot(`

--- a/packages/searchkit-api/src/queryRules.ts
+++ b/packages/searchkit-api/src/queryRules.ts
@@ -12,6 +12,7 @@ export interface QueryContext {
 }
 
 export interface QueryRuleActions {
+  ruleIds: string[]
   pinnedDocs: string[]
   boostFunctions: any[]
   query: string
@@ -77,6 +78,7 @@ export const getQueryRulesActionsFromRequest = (
       return sum
     },
     {
+      ruleIds: satisfiedRules.map((rule) => rule.id),
       pinnedDocs: [],
       boostFunctions: [],
       query: queryContext.query,

--- a/packages/searchkit-api/src/transformResponse.ts
+++ b/packages/searchkit-api/src/transformResponse.ts
@@ -176,6 +176,7 @@ export default function transformResponse(
 ) {
   try {
     return {
+      appliedRules: queryRuleActions.ruleIds,
       exhaustiveNbHits: true,
       exhaustiveFacetsCount: true,
       exhaustiveTypo: true,


### PR DESCRIPTION
Query Rules: Expose rule ids in API in Search Response