### PR TITLE
Instantsearch-client: Browser only support

### DIFF
--- a/.changeset/giant-carrots-shout.md
+++ b/.changeset/giant-carrots-shout.md
@@ -1,0 +1,5 @@
+---
+'@searchkit/instantsearch-client': minor
+---
+
+Support for browser only use-case

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,21 @@
             "sourceMaps": true
         },
         {
+            "name": "@searchkit/instantsearch-client Tests ",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+            "args": [
+                 "--runInBand", "--forceExit", "--detectOpenHandles", "--watch"
+            ],
+            "cwd": "${workspaceRoot}/packages/searchkit-instantsearch-client",
+            "env": {
+                "NODE_ENV": "test"
+            },
+            "console": "integratedTerminal",
+            "sourceMaps": true
+        },
+        {
           "name": "apps/web debug server-side",
           "type": "node",
           "request": "launch",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@algolia/autocomplete-js": "^1.7.4",
     "@searchkit/api": "4.0.0",
     "@searchkit/instantsearch-client": "4.0.0",
+    "@algolia/autocomplete-theme-classic": "^1.7.4",
     "algoliasearch": "^4.14.2",
     "autoprefixer": "^10.4.12",
     "next": "12.3.1",
@@ -26,7 +27,6 @@
     "swr": "^1.3.0"
   },
   "devDependencies": {
-    "@algolia/autocomplete-theme-classic": "^1.7.4",
     "@babel/core": "^7.0.0",
     "@types/node": "^17.0.12",
     "@types/react": "18.0.17",

--- a/apps/web/pages/api/config.ts
+++ b/apps/web/pages/api/config.ts
@@ -1,0 +1,146 @@
+export const config = {
+  connection: {
+    host: 'https://commerce-demo.es.us-east4.gcp.elastic-cloud.com:9243',
+    apiKey: 'a2Rha1VJTUJMcGU4ajA3Tm9fZ0Y6MjAzX2pLbURTXy1hNm9SUGZGRlhJdw=='
+  },
+  search_settings: {
+    highlight_attributes: ['title'],
+    search_attributes: [{ field: 'title', weight: 3 }, 'actors', 'plot'],
+    result_attributes: ['title', 'actors', 'poster', 'plot'],
+    facet_attributes: [
+      'type',
+      { attribute: 'actors', field: 'actors.keyword', type: 'string' },
+      'rated',
+      { attribute: 'imdbrating', type: 'numeric', field: 'imdbrating' },
+      { attribute: 'metascore', type: 'numeric', field: 'metascore' }
+    ],
+    sorting: {
+      default: {
+        field: '_score',
+        order: 'desc'
+      },
+      _rated_desc: {
+        field: 'rated',
+        order: 'desc'
+      }
+    },
+    snippet_attributes: ['plot'],
+    query_rules: [
+      {
+        id: '1',
+        conditions: [[]],
+        actions: [
+          {
+            action: 'RenderFacetsOrder',
+            facetAttributesOrder: ['type', 'actors', 'rated', 'metascore']
+          }
+        ]
+      },
+      {
+        id: '2',
+        conditions: [
+          [
+            {
+              context: 'filterPresent',
+              values: [{ attribute: 'type', value: 'movie' }]
+            }
+          ]
+        ],
+        actions: [
+          {
+            action: 'RenderFacetsOrder',
+            facetAttributesOrder: ['type', 'actors', 'rated', 'imdbrating', 'metascore']
+          }
+        ]
+      },
+      {
+        id: '3',
+        conditions: [
+          [
+            {
+              context: 'query',
+              match_type: 'prefix',
+              value: 'star'
+            }
+          ]
+        ],
+        actions: [
+          {
+            action: 'PinnedResult',
+            documentIds: ['tt0111161']
+          }
+        ]
+      },
+      {
+        id: '4',
+        conditions: [
+          [
+            {
+              context: 'query',
+              match_type: 'exact',
+              value: 'episode'
+            }
+          ]
+        ],
+        actions: [
+          {
+            action: 'RenderUserData',
+            userData: '{ "title": "Episode" }'
+          },
+          {
+            action: 'RenderFacetsOrder',
+            facetAttributesOrder: ['type']
+          },
+          {
+            action: 'QueryRewrite',
+            query: 'tv episodes'
+          }
+        ]
+      },
+      {
+        id: '5',
+        conditions: [
+          [
+            {
+              context: 'filterPresent',
+              values: [{ attribute: 'type', value: 'movie' }]
+            }
+          ]
+        ],
+        actions: [
+          {
+            action: 'RenderUserData',
+            userData: '{ "title": "Movie has been selected" }'
+          },
+          {
+            action: 'PinnedResult',
+            documentIds: ['tt0468569']
+          }
+        ]
+      },
+      {
+        id: '6',
+        conditions: [
+          [
+            {
+              context: 'query',
+              value: 'movie',
+              match_type: 'exact'
+            }
+          ]
+        ],
+        actions: [
+          {
+            action: 'QueryBoost',
+            query: 'actors:"Dan Aykroyd" OR actors:"Charlie Sheen"',
+            weight: 2
+          },
+          {
+            action: 'QueryFilter',
+            query: 'type:"movie"'
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/web/pages/browser-only-demo.jsx
+++ b/apps/web/pages/browser-only-demo.jsx
@@ -1,0 +1,100 @@
+import { InstantSearch, SearchBox, Hits, Highlight, DynamicWidgets, RefinementList, ToggleRefinement, Panel, Pagination, Stats, connectSearchBox, NumericMenu, RangeInput, CurrentRefinements, QueryRuleCustomData, Snippet, SortBy } from 'react-instantsearch-dom';
+import Client from '@searchkit/instantsearch-client'
+import Script from 'next/script'
+import Searchkit, { SearchkitConfig } from "searchkit"
+import { config } from "./api/config"
+
+const searchkitClient = new Searchkit(config)
+
+const searchClient = Client(searchkitClient);
+
+
+// const searchClient = Client({
+//   url: '/api/search',
+// });
+
+const hitView = (props) => {
+  return (
+    <div>
+      <img src={props.hit.poster} className="hit-image" />
+      <h2><Highlight hit={props.hit} attribute="title" /></h2>
+      <br />
+      
+      <Snippet hit={props.hit} attribute="plot" />
+
+    </div>
+  )
+}
+
+export default function Web() {
+    return (
+      <div className="ais-InstantSearch bg-gray-100 h-screen p-4">
+        <Script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c98b302ea3bb4a33a012a7ef0ab3e240"}' />
+  
+      <InstantSearch
+        indexName="imdb_movies"
+        searchClient={searchClient}
+      >
+        <SearchBox />
+        <div className="left-panel">
+          {/* @ts-ignore */}
+          <DynamicWidgets maxValuesPerFacet={5} fallbackWidget={RefinementList}>
+            <Panel header="Type">
+              <RefinementList attribute="type" searchable={true}/>
+            </Panel>
+            <Panel header="actors">
+              <RefinementList attribute="actors" searchable={true} limit={10} />
+            </Panel>
+            <Panel header="imdbrating">
+              <NumericMenu
+                attribute="imdbrating"
+                items={[
+                  { label: '5 - 7', start: 5, end: 7 },
+                  { label: '7 - 9', start: 7, end: 9 },
+                  { label: '>= 9', start: 9 },
+                ]}
+              />
+            </Panel>
+            <Panel header="metascore">
+              <RangeInput attribute="metascore" header="Range Input" />
+            </Panel>
+          </DynamicWidgets>
+        </div>
+        <div className="right-panel">
+        <QueryRuleCustomData>
+        {({ items }) =>
+          items.map(({ title }) => {
+            if (!title) {
+              return null;
+            }
+
+            return (
+              <section key={title}>
+                <h2>{title}</h2>
+                <p>You have typed in movie, show something wild about movies!</p>
+              </section>
+            );
+          })
+        }
+      </QueryRuleCustomData>
+        <div className="flex">
+          <div className="flex-auto w-full py-2 px-4">
+            <Stats />
+            <CurrentRefinements />
+          </div>
+          <div className="flex-none">
+            <SortBy defaultRefinement='imdb_movies' items={[
+              { value: 'imdb_movies', label: 'Relevance' },
+              { value: 'imdb_movies_rated_desc', label: 'Highly Rated Movies' },
+            ]}
+            />
+          </div>
+          </div>
+
+          <Hits hitComponent={hitView}/>
+          <Pagination />
+        </div>
+      </InstantSearch>
+      </div>
+    );
+}

--- a/apps/web/pages/demos.mdx
+++ b/apps/web/pages/demos.mdx
@@ -8,3 +8,4 @@ Here are some live demos, that show Searchkit used for different use cases.
 | [Fashion Ecommerce](/demo-ecommerce) | [Code](https://github.com/searchkit/searchkit/tree/main/apps/web/pages/demo-ecommerce.tsx) | Fashion Ecommerce |
 | [Autocomplete Demo](/autocomplete) | [Code](https://github.com/searchkit/searchkit/tree/main/apps/web/pages/autocomplete.jsx) | Autocomplete Demo for IMDB movies |
 | [Server Rendered Next Demo with Routing](/ssr-demo) | [Code](https://github.com/searchkit/searchkit/tree/main/apps/web/pages/ssr-demo.jsx) | SSR rendered page with routing configured |
+| [Browser talking to Elasticsearch directly](/browser-only-demo) | [Code](https://github.com/searchkit/searchkit/tree/main/apps/web/pages/browser-only-demo.jsx) | For when you want to talk to Elasticsearch directly from the browser, this example shows how to use Searchkit and the client together to call Elasticsearch from the browser, without needing a node API layer. |

--- a/apps/web/pages/docs/api-documentation/instantsearch-client.mdx
+++ b/apps/web/pages/docs/api-documentation/instantsearch-client.mdx
@@ -66,3 +66,29 @@ const searchClient = Client({
   }),
 });
 ```
+
+### Use Elasticsearch Directly
+
+You can also use the client to directly query Elasticsearch from the browser, skipping needing a node API in the middle. This is useful if you're proxying the Elasticsearch API through your own application API.
+
+[Working demo](/browser-only-demo) available.
+
+```js
+
+import Client from '@searchkit/instantsearch-client'
+import Script from 'next/script'
+import Searchkit, { SearchkitConfig } from "searchkit"
+import { config } from "./api/config"
+
+const searchkitClient = new Searchkit({
+  connection: {
+    host: "http://localhost:9200"
+  },
+  search_settings: {
+    // ... see Node API docs for configuration options
+  }
+})
+
+const searchClient = Client(searchkitClient);
+
+```

--- a/packages/searchkit-instantsearch-client/jest.config.js
+++ b/packages/searchkit-instantsearch-client/jest.config.js
@@ -1,7 +1,11 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  testTimeout: 70000,
-  transform: {}
+const config = {
+  transform: {
+    "\\.[jt]sx?$": ["ts-jest", { "useESM": true }],
+  },
+  moduleNameMapper: {
+    "(.+)\\.js": "$1"
+  },
+  extensionsToTreatAsEsm: [".ts"],
 };
+
+export default config;

--- a/packages/searchkit-instantsearch-client/package.json
+++ b/packages/searchkit-instantsearch-client/package.json
@@ -33,6 +33,9 @@
     "typescript": "^4.5.2",
     "tsup": "^6.3.0"
   },
+  "dependencies": {
+    "searchkit": "^4.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/searchkit-instantsearch-client/test/APIClient.test.ts
+++ b/packages/searchkit-instantsearch-client/test/APIClient.test.ts
@@ -1,0 +1,24 @@
+import FrontendClient from '../src/index'
+import nock from 'nock'
+import { HitsResponseWithFacetFilter } from '../../searchkit/src/___tests___/mocks/ElasticsearchResponses'
+import { DisjunctiveExampleRequest } from '../../searchkit/src/___tests___/mocks/AlgoliaRequests'
+import 'cross-fetch/polyfill'
+
+describe('API connector', () => {
+  it('works as expected', async () => {
+    const x = FrontendClient({
+      url: 'http://localhost:3000/api/search'
+    })
+
+    nock('http://localhost:3000/')
+      .post('/api/search', (requestBody: any) => {
+        expect(requestBody).toMatchSnapshot('Algolia request')
+        return requestBody
+      })
+      .reply(200, HitsResponseWithFacetFilter)
+
+    const response = await x.search(DisjunctiveExampleRequest as any)
+
+    expect(response).toMatchSnapshot()
+  })
+})

--- a/packages/searchkit-instantsearch-client/test/__snapshots__/APIClient.test.ts.snap
+++ b/packages/searchkit-instantsearch-client/test/__snapshots__/APIClient.test.ts.snap
@@ -1,0 +1,185 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`API connector works as expected 1`] = `
+{
+  "responses": [
+    {
+      "_shards": {
+        "failed": 0,
+        "skipped": 0,
+        "successful": 1,
+        "total": 1,
+      },
+      "aggregations": {
+        "actors": {
+          "buckets": [
+            {
+              "doc_count": 1,
+              "key": "Bob Gunton",
+            },
+            {
+              "doc_count": 1,
+              "key": "Morgan Freeman",
+            },
+            {
+              "doc_count": 1,
+              "key": "Tim Robbins",
+            },
+            {
+              "doc_count": 1,
+              "key": "William Sadler",
+            },
+          ],
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+        },
+        "rated": {
+          "buckets": [
+            {
+              "doc_count": 1,
+              "key": "R",
+            },
+          ],
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+        },
+        "type": {
+          "buckets": [
+            {
+              "doc_count": 1,
+              "key": "movie",
+            },
+          ],
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+        },
+      },
+      "hits": {
+        "hits": [
+          {
+            "_id": "tt0111161",
+            "_index": "imdb_movies",
+            "_score": 7.637228,
+            "_source": {
+              "actors": [
+                "Tim Robbins",
+                "Morgan Freeman",
+                "Bob Gunton",
+                "William Sadler",
+              ],
+              "title": "The Shawshank Redemption",
+            },
+            "highlight": {
+              "title": [
+                "The <em>Shawshank</em> Redemption",
+              ],
+            },
+          },
+        ],
+        "max_score": 7.637228,
+        "total": {
+          "relation": "eq",
+          "value": 1,
+        },
+      },
+      "status": 200,
+      "timed_out": false,
+      "took": 2,
+    },
+    {
+      "_shards": {
+        "failed": 0,
+        "skipped": 0,
+        "successful": 1,
+        "total": 1,
+      },
+      "aggregations": {
+        "type": {
+          "buckets": [
+            {
+              "doc_count": 1,
+              "key": "movie",
+            },
+          ],
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+        },
+      },
+      "hits": {
+        "hits": [
+          {
+            "_id": "tt0111161",
+            "_index": "imdb_movies",
+            "_score": 7.637228,
+            "_source": {
+              "actors": [
+                "Tim Robbins",
+                "Morgan Freeman",
+                "Bob Gunton",
+                "William Sadler",
+              ],
+              "title": "The Shawshank Redemption",
+            },
+            "highlight": {
+              "title": [
+                "The <em>Shawshank</em> Redemption",
+              ],
+            },
+          },
+        ],
+        "max_score": 7.637228,
+        "total": {
+          "relation": "eq",
+          "value": 1,
+        },
+      },
+      "status": 200,
+      "timed_out": false,
+      "took": 2,
+    },
+  ],
+  "took": 2,
+}
+`;
+
+exports[`API connector works as expected: Algolia request 1`] = `
+[
+  {
+    "indexName": "imdb_movies",
+    "params": {
+      "facetFilters": [
+        [
+          "type:movie",
+        ],
+      ],
+      "facets": [
+        "*",
+      ],
+      "highlightPostTag": "</em>",
+      "highlightPreTag": "<em>",
+      "maxValuesPerFacet": 10,
+      "page": 0,
+      "query": "shawshank",
+      "tagFilters": "",
+    },
+  },
+  {
+    "indexName": "imdb_movies",
+    "params": {
+      "analytics": false,
+      "attributesToHighlight": [],
+      "attributesToRetrieve": [],
+      "attributesToSnippet": [],
+      "clickAnalytics": false,
+      "facets": "type",
+      "highlightPostTag": "</em>",
+      "highlightPreTag": "<em>",
+      "hitsPerPage": 1,
+      "maxValuesPerFacet": 10,
+      "page": 0,
+      "query": "shawshank",
+      "tagFilters": "",
+    },
+  },
+]
+`;

--- a/packages/searchkit-instantsearch-client/test/__snapshots__/browserOnly.test.ts.snap
+++ b/packages/searchkit-instantsearch-client/test/__snapshots__/browserOnly.test.ts.snap
@@ -1,0 +1,207 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Browser Only Searchkit works as expected 1`] = `
+{
+  "results": [
+    {
+      "appliedRules": [],
+      "exhaustive": {
+        "facetsCount": true,
+        "nbHits": true,
+        "typo": true,
+      },
+      "exhaustiveFacetsCount": true,
+      "exhaustiveNbHits": true,
+      "exhaustiveTypo": true,
+      "facets": {
+        "actors": {
+          "Bob Gunton": 1,
+          "Morgan Freeman": 1,
+          "Tim Robbins": 1,
+          "William Sadler": 1,
+        },
+        "rated": {
+          "R": 1,
+        },
+        "type": {
+          "movie": 1,
+        },
+      },
+      "facets_stats": {},
+      "hits": [
+        {
+          "_highlightResult": {
+            "actors": [
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Tim Robbins",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Morgan Freeman",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Bob Gunton",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "William Sadler",
+              },
+            ],
+            "title": {
+              "fullyHighlighted": false,
+              "matchLevel": "full",
+              "matchedWords": [
+                "Shawshank",
+              ],
+              "value": "The <em>Shawshank</em> Redemption",
+            },
+          },
+          "actors": [
+            "Tim Robbins",
+            "Morgan Freeman",
+            "Bob Gunton",
+            "William Sadler",
+          ],
+          "objectID": "tt0111161",
+          "title": "The Shawshank Redemption",
+        },
+      ],
+      "hitsPerPage": 20,
+      "index": "imdb_movies",
+      "nbHits": 1,
+      "nbPages": 1,
+      "page": 0,
+      "params": "facetFilters=&facets=*&highlightPostTag=%3C%2Fem%3E&highlightPreTag=%3Cem%3E&maxValuesPerFacet=10&page=0&query=shawshank&tagFilters=",
+      "processingTimeMS": 2,
+      "query": "shawshank",
+      "renderingContent": {
+        "facetOrdering": {
+          "facets": {
+            "order": [
+              "type",
+              "actors",
+              "rated",
+            ],
+          },
+          "values": {
+            "actors": {
+              "sortRemainingBy": "count",
+            },
+            "rated": {
+              "sortRemainingBy": "count",
+            },
+            "type": {
+              "sortRemainingBy": "count",
+            },
+          },
+        },
+      },
+    },
+    {
+      "appliedRules": [],
+      "exhaustive": {
+        "facetsCount": true,
+        "nbHits": true,
+        "typo": true,
+      },
+      "exhaustiveFacetsCount": true,
+      "exhaustiveNbHits": true,
+      "exhaustiveTypo": true,
+      "facets": {
+        "type": {
+          "movie": 1,
+        },
+      },
+      "facets_stats": {},
+      "hits": [
+        {
+          "_highlightResult": {
+            "actors": [
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Tim Robbins",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Morgan Freeman",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Bob Gunton",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "William Sadler",
+              },
+            ],
+            "title": {
+              "fullyHighlighted": false,
+              "matchLevel": "full",
+              "matchedWords": [
+                "Shawshank",
+              ],
+              "value": "The <em>Shawshank</em> Redemption",
+            },
+          },
+          "actors": [
+            "Tim Robbins",
+            "Morgan Freeman",
+            "Bob Gunton",
+            "William Sadler",
+          ],
+          "objectID": "tt0111161",
+          "title": "The Shawshank Redemption",
+        },
+      ],
+      "hitsPerPage": 1,
+      "index": "imdb_movies",
+      "nbHits": 1,
+      "nbPages": 1,
+      "page": 0,
+      "params": "analytics=false&clickAnalytics=false&facets=type&highlightPostTag=%3C%2Fem%3E&highlightPreTag=%3Cem%3E&hitsPerPage=1&maxValuesPerFacet=10&page=0&query=shawshank&tagFilters=",
+      "processingTimeMS": 2,
+      "query": "shawshank",
+      "renderingContent": {
+        "facetOrdering": {
+          "facets": {
+            "order": [
+              "type",
+              "actors",
+              "rated",
+            ],
+          },
+          "values": {
+            "actors": {
+              "sortRemainingBy": "count",
+            },
+            "rated": {
+              "sortRemainingBy": "count",
+            },
+            "type": {
+              "sortRemainingBy": "count",
+            },
+          },
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`Browser Only Searchkit works as expected: ES Request 1`] = `
+"{"index":"imdb_movies"}
+{"aggs":{"type":{"terms":{"field":"type","size":10}},"actors":{"terms":{"field":"actors.keyword","size":10}},"rated":{"terms":{"field":"rated","size":10}}},"query":{"bool":{"filter":[{"bool":{"should":[{"term":{"type":"movie"}}]}}],"must":{"bool":{"should":[{"bool":{"should":[{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"fuzziness":"AUTO:4,8"}},{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"type":"bool_prefix"}}]}},{"multi_match":{"query":"shawshank","type":"phrase","fields":["title","actors","query"]}}]}}}},"size":20,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
+{"index":"imdb_movies"}
+{"aggs":{"type":{"terms":{"field":"type","size":10}}},"query":{"bool":{"filter":[],"must":{"bool":{"should":[{"bool":{"should":[{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"fuzziness":"AUTO:4,8"}},{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"type":"bool_prefix"}}]}},{"multi_match":{"query":"shawshank","type":"phrase","fields":["title","actors","query"]}}]}}}},"size":1,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
+"
+`;

--- a/packages/searchkit-instantsearch-client/test/browserOnly.test.ts
+++ b/packages/searchkit-instantsearch-client/test/browserOnly.test.ts
@@ -1,0 +1,42 @@
+import Searchkit, { SearchkitConfig } from 'searchkit'
+import FrontendClient from '../src/index'
+import nock from 'nock'
+import { HitsResponseWithFacetFilter } from '../../searchkit/src/___tests___/mocks/ElasticsearchResponses'
+import { DisjunctiveExampleRequest } from '../../searchkit/src/___tests___/mocks/AlgoliaRequests'
+import 'cross-fetch/polyfill'
+
+describe('Browser Only Searchkit', () => {
+  it('works as expected', async () => {
+    const config: SearchkitConfig = {
+      connection: {
+        host: 'http://localhost:9200',
+        apiKey: 'a2Rha1VJTUJMcGU4ajA3Tm9fZ0Y6MjAzX2pLbURTXy1hNm9SUGZGRlhJdw=='
+      },
+      search_settings: {
+        highlight_attributes: ['title', 'actors'],
+        search_attributes: ['title', 'actors', 'query'],
+        result_attributes: ['title', 'actors', 'query'],
+        facet_attributes: [
+          'type',
+          { field: 'actors.keyword', attribute: 'actors', type: 'string' },
+          'rated'
+        ]
+      }
+    }
+
+    const client = new Searchkit(config)
+
+    const x = FrontendClient(client)
+
+    nock('http://localhost:9200')
+      .post('/_msearch', (requestBody: any) => {
+        expect(requestBody).toMatchSnapshot('ES Request')
+        return requestBody
+      })
+      .reply(200, HitsResponseWithFacetFilter)
+
+    const response = await x.search(DisjunctiveExampleRequest as any)
+
+    expect(response).toMatchSnapshot()
+  })
+})

--- a/packages/searchkit-instantsearch-client/tsconfig.json
+++ b/packages/searchkit-instantsearch-client/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "include": ["."],
+  "compilerOptions": {
+    "allowJs" : true,
+  },
   "exclude": ["dist", "build", "node_modules"]
 }


### PR DESCRIPTION
You can also use the client to directly query Elasticsearch from the browser, skipping needing a node API in the middle. This is useful if you're proxying the Elasticsearch API through your own application API.
