### PR TITLE
feat: add support for negative numbers and numeric ranges

### DIFF
--- a/.changeset/yellow-mangos-yawn.md
+++ b/.changeset/yellow-mangos-yawn.md
@@ -1,0 +1,7 @@
+---
+'searchkit': patch
+'@searchkit/api': patch
+'@searchkit/instantsearch-client': patch
+---
+
+Fix support for negative numbers

--- a/packages/searchkit/src/___tests___/filters.test.ts
+++ b/packages/searchkit/src/___tests___/filters.test.ts
@@ -114,11 +114,14 @@ describe('filter functions', () => {
     `)
   })
 
-  it('ignores malformed numeric filters', () => {
+  it('throws on malformed numeric filters', () => {
     const numericFilter = `price xxx 100`
 
-    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config))
-      .toMatchInlineSnapshot(`[]`)
+    expect(() =>
+      transformNumericFilters(getNumericFilterRequest(numericFilter), config)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Numeric filter "price xxx 100" could not be parsed. It should either be in the format "attributeName operator operand" or "attributeName: lowerBound TO upperBound""`
+    )
   })
 
   it('filters without fields', () => {

--- a/packages/searchkit/src/___tests___/filters.test.ts
+++ b/packages/searchkit/src/___tests___/filters.test.ts
@@ -1,4 +1,4 @@
-import { transformBaseFilters } from '../filters'
+import { transformBaseFilters, transformNumericFilters } from '../filters'
 import { SearchSettingsConfig } from '../types'
 import { DisjunctiveExampleRequest } from './mocks/AlgoliaRequests'
 
@@ -6,7 +6,8 @@ describe('filter functions', () => {
   const config: SearchSettingsConfig = {
     facet_attributes: [
       { attribute: 'author', field: 'author.keyword', type: 'string' },
-      { attribute: 'price', field: 'price', type: 'numeric' }
+      { attribute: 'price', field: 'price', type: 'numeric' },
+      { attribute: 'discount', field: 'discount', type: 'numeric' },
     ],
     filter_attributes: [
       { attribute: 'publisher', field: 'publisher.keyword', type: 'string' },
@@ -26,6 +27,14 @@ describe('filter functions', () => {
     }
   })
 
+  const getNumericFilterRequest = (numericFilter: string) => ({
+    ...DisjunctiveExampleRequest[0],
+    params: {
+      ...(DisjunctiveExampleRequest[0] as any).params,
+      numericFilters: [numericFilter]
+    }
+  })
+
   it('should transform an instantsearch filter to an elasticsearch filter', () => {
     const isFilter = `(author:"Stephen King" OR genre:"Horror") AND publisher:"Penguin"`
 
@@ -38,6 +47,78 @@ describe('filter functions', () => {
         },
       ]
     `)
+  })
+
+  it('should transform an instantsearch numeric filter to an elasticsearch filter', () => {
+    const numericFilter = `discount<10`
+
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config)).toMatchInlineSnapshot(`
+      [
+        {
+          "range": {
+            "discount": {
+              "lt": "10",
+            },
+          },
+        },
+      ]
+    `)
+  })
+
+  it('transforms negative numeric values', () => {
+    const numericFilter = `discount<-10`
+
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config)).toMatchInlineSnapshot(`
+      [
+        {
+          "range": {
+            "discount": {
+              "lt": "-10",
+            },
+          },
+        },
+      ]
+    `)
+  })
+
+  it('supports low to high numeric filters', () => {
+    const numericFilter = `price:100 TO 1000`
+
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config)).toMatchInlineSnapshot(`
+      [
+        {
+          "range": {
+            "price": {
+              "gte": "100",
+              "lte": "1000",
+            },
+          },
+        },
+      ]
+    `)
+  })
+
+  it('transforms numeric values with whitespace', () => {
+    const numericFilter = `price >= 100`
+
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config)).toMatchInlineSnapshot(`
+      [
+        {
+          "range": {
+            "price": {
+              "gte": "100",
+            },
+          },
+        },
+      ]
+    `)
+  })
+
+  it('ignores malformed numeric filters', () => {
+    const numericFilter = `price xxx 100`
+
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config))
+      .toMatchInlineSnapshot(`[]`)
   })
 
   it('filters without fields', () => {

--- a/packages/searchkit/src/filters.ts
+++ b/packages/searchkit/src/filters.ts
@@ -20,18 +20,35 @@ export const transformNumericFilters = (
     return []
   }
 
-  return numericFilters.reduce((sum, filter) => {
-    const [match, field, operator, value] = filter.match(
-      /([\w\.\_\-]+)(\=|\!\=|\>|\>\=|\<|\<\=)(\d+)/
+  return numericFilters.reduce((sum, filter: string) => {
+    let match, field, operator, value, maxValue = ''
+    let groups = filter.match(
+      /([\w\.\_\-]+)\s*(\=|\!\=|\>|\>\=|\<|\<\=)\s*(-?\d+)/
     )
+
+    if (groups) {
+      [match, field, operator, value] = groups
+      value
+    }
+    else {
+      // Alternative syntax: 'attribute:lower_value TO higher_value'
+      groups = filter.match(
+        /([\w\.\_\-]+):\s*(-?\d+)\s*([Tt][Oo])\s*(-?\d+)/
+      )
+
+      // Malformed numeric filter
+      if (!groups) {
+        return sum
+      }
+
+      [match, field, value, operator, maxValue] = groups
+    }
 
     const facetFilterMap = getFacetFilterMap(
       config.facet_attributes || [],
       config.filter_attributes || []
     )
     const facetFilterConfig = facetFilterMap[field]
-
-    if (!match) return sum
 
     const getFilter = (field: string, operator: string, value: string) => {
       if (operator === '=') {
@@ -79,6 +96,15 @@ export const transformNumericFilters = (
           range: {
             [field]: {
               lte: value
+            }
+          }
+        }
+      } else if (operator.toUpperCase() === 'TO') {
+        return {
+          range: {
+            [field]: {
+              gte: value,
+              lte: maxValue,
             }
           }
         }

--- a/packages/searchkit/src/filters.ts
+++ b/packages/searchkit/src/filters.ts
@@ -28,7 +28,6 @@ export const transformNumericFilters = (
 
     if (groups) {
       [match, field, operator, value] = groups
-      value
     }
     else {
       // Alternative syntax: 'attribute:lower_value TO higher_value'
@@ -36,9 +35,10 @@ export const transformNumericFilters = (
         /([\w\.\_\-]+):\s*(-?\d+)\s*([Tt][Oo])\s*(-?\d+)/
       )
 
-      // Malformed numeric filter
       if (!groups) {
-        return sum
+        throw new Error(
+          `Numeric filter "${filter}" could not be parsed. It should either be in the format "attributeName operator operand" or "attributeName: lowerBound TO upperBound"`
+        );
       }
 
       [match, field, value, operator, maxValue] = groups


### PR DESCRIPTION
Fixes an issue in `transformNumericFilters` where negative values were rejected - e.g. `discount<-10` and adds support for the numeric range format detailed here: https://www.algolia.com/doc/api-reference/api-parameters/numericFilters/#numeric-range