### PR TITLE
KNN Support

### DIFF
--- a/.changeset/calm-comics-love.md
+++ b/.changeset/calm-comics-love.md
@@ -1,0 +1,7 @@
+---
+'searchkit': minor
+'@searchkit/api': minor
+'@searchkit/instantsearch-client': minor
+---
+
+Added 1st class support for KNN search

--- a/apps/web/pages/docs/api-documentation/searchkit.mdx
+++ b/apps/web/pages/docs/api-documentation/searchkit.mdx
@@ -445,6 +445,42 @@ To see the full Elasticsearch query that is executed to Elasticsearch, you can r
   });
 ```
 
+##### Example: Exclude BM25 Query
+If you're using KNN exclusively, you might want to exclude the BM25 query from the Elasticsearch query. You can do this by overriding the `getQuery` function and returning false.
+
+```tsx
+  const results = await client.handleRequest(req.body, {
+    getQuery: () => {
+      return false
+    }
+  });
+```
+
+#### `getKnnQuery` optional function
+If you want to specify a KNN query, you can use the `getKnnQuery` function. The function must return an Elasticsearch KNN query. You can read more about the KNN query DSL [here](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/knn-search.html#semantic-search).
+
+```tsx
+  const results = await client.handleRequest(req.body, {
+    getKnnQuery(query, search_attributes, config) {
+      return {
+        field: 'dense-vector-field',
+        k: 10,
+        num_candidates: 100,
+        query_vector_builder: {
+          text_embedding: {
+            model_id: 'cookie_model',
+            model_text: query
+          }
+        }
+      }
+    },
+    // Optional: You may want to exclude the BM25 query
+    getQuery: () => {
+      return false
+    }
+  });
+```
+
 ##### Function Parameters
 
 - **query**: The query string from the search request.

--- a/apps/web/pages/docs/getting-started/with-react.mdx
+++ b/apps/web/pages/docs/getting-started/with-react.mdx
@@ -257,37 +257,24 @@ const searchClient = Client(sk, {
 
 You might want to transform the query terms into a vector embedding before searching. This is useful if you want to do semantic search.
 
-Searchkit provides a way to customise the whole search DSL. This is useful if you want to do a vector search via KNN. See [Search Hooks](/docs/guides/customising-query#example-of-doing-a-knn-search) for an example.
+Searchkit provides a way to customise the whole search DSL. This is useful if you want to do a vector search via KNN.
 
 ```tsx
 import Client from '@searchkit/instantsearch-client';
 
 const searchClient = Client(sk, {
-  hooks: {
-    beforeSearch: async (searchRequests) => {
-      const [uiRequest] = searchRequests
-      const query = uiRequest.request.params.query
-      
-      if (!query) {
-        return searchRequests
-      }
-
-      const textVector = await vectorizeText(query);
-
-      return searchRequests.map((sr) => {
-          return {
-            ...sr,
-            body: {
-              ...sr.body,
-              knn: {
-                  "field": "text_embedding",
-                  "query_vector": textVector.vector,
-                  "k": 10,
-                  "num_candidates": 100
-              }
-            }
+  getKnnQuery(query, search_attributes, config) {
+    return {
+      field: 'dense-vector-field',
+      k: 10,
+      num_candidates: 100,
+      // supported in latest version of Elasticsearch
+      query_vector_builder: { 
+        text_embedding: {
+          model_id: 'cookie_model',
+          model_text: query
         }
-      })
+      }
     }
   }
 });

--- a/apps/web/pages/docs/guides/customising-query.mdx
+++ b/apps/web/pages/docs/guides/customising-query.mdx
@@ -80,31 +80,18 @@ An example of extending the query to do a hybrid search with KNN search and text
 
 ```ts
   const results = await client.handleRequest(req.body, {
-    hooks: {
-      beforeSearch: async (searchRequests) => {
-        const [uiRequest] = searchRequests
-        const query = uiRequest.request.params.query
-        
-        if (!query) {
-          return searchRequests
-        }
-
-        const textVector = await vectorizeText(query);
-
-        return searchRequests.map((sr) => {
-            return {
-              ...sr,
-              body: {
-                ...sr.body,
-                knn: {
-                    "field": "text_embedding",
-                    "query_vector": textVector.vector,
-                    "k": 10,
-                    "num_candidates": 100
-                }
-              }
+    getKnnQuery(query, search_attributes, config) {
+      return {
+        field: 'dense-vector-field',
+        k: 10,
+        num_candidates: 100,
+        // supported in latest version of Elasticsearch
+        query_vector_builder: { 
+          text_embedding: {
+            model_id: 'cookie_model',
+            model_text: query
           }
-        })
+        }
       }
     }
   });

--- a/packages/searchkit/package.json
+++ b/packages/searchkit/package.json
@@ -41,7 +41,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@elastic/elasticsearch": "8.4.0",
+    "@elastic/elasticsearch": "^8.7.0",
     "@types/jest": "^29.1.1",
     "cross-fetch": "^3.1.5",
     "eslint": "^7.32.0",

--- a/packages/searchkit/src/___tests___/functional/KNNSearch.test.ts
+++ b/packages/searchkit/src/___tests___/functional/KNNSearch.test.ts
@@ -1,0 +1,67 @@
+import nock from 'nock'
+import Client, { AlgoliaMultipleQueriesQuery } from '../../'
+import { DisjunctiveExampleRequest } from '../mocks/AlgoliaRequests'
+import { HitsResponseWithFacetFilter } from '../mocks/ElasticsearchResponses'
+
+describe('KNNSearch', () => {
+  it('should return results', async () => {
+    const client = new Client({
+      connection: {
+        host: 'http://localhost:9200',
+        apiKey: 'a2Rha1VJTUJMcGU4ajA3Tm9fZ0Y6MjAzX2pLbURTXy1hNm9SUGZGRlhJdw=='
+      },
+      search_settings: {
+        highlight_attributes: ['title', 'actors'],
+        search_attributes: ['title', 'actors', 'query'],
+        result_attributes: ['title', 'actors', 'query'],
+        facet_attributes: [
+          'type',
+          { field: 'actors.keyword', attribute: 'actors', type: 'string' },
+          'rated'
+        ]
+      }
+    })
+
+    nock('http://localhost:9200')
+      .post('/_msearch', (requestBody: any) => {
+        expect(requestBody).toMatchSnapshot('ES Request')
+        const x = JSON.parse(requestBody.split('\n')[1]).knn
+        expect(x).toMatchInlineSnapshot(`
+          {
+            "field": "dense-vector-field",
+            "k": 10,
+            "num_candidates": 100,
+            "query_vector_builder": {
+              "text_embedding": {
+                "model_id": "cookie_model",
+                "model_text": "shawshank",
+              },
+            },
+          }
+        `)
+        return true
+      })
+      .reply(200, HitsResponseWithFacetFilter)
+
+    const response = await client.handleInstantSearchRequests(
+      DisjunctiveExampleRequest as AlgoliaMultipleQueriesQuery[],
+      {
+        getKnnQuery(query, search_attributes, config) {
+          return {
+            field: 'dense-vector-field',
+            k: 10,
+            num_candidates: 100,
+            query_vector_builder: {
+              text_embedding: {
+                model_id: 'cookie_model',
+                model_text: query
+              }
+            }
+          }
+        }
+      }
+    )
+
+    expect(response).toBeTruthy()
+  })
+})

--- a/packages/searchkit/src/___tests___/functional/__snapshots__/KNNSearch.test.ts.snap
+++ b/packages/searchkit/src/___tests___/functional/__snapshots__/KNNSearch.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KNNSearch should return results: ES Request 1`] = `
+"{"index":"imdb_movies"}
+{"aggs":{"type":{"terms":{"field":"type","size":10}},"actors":{"terms":{"field":"actors.keyword","size":10}},"rated":{"terms":{"field":"rated","size":10}}},"query":{"bool":{"filter":[{"bool":{"should":[{"term":{"type":"movie"}}]}}],"must":{"bool":{"should":[{"bool":{"should":[{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"fuzziness":"AUTO:4,8"}},{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"type":"bool_prefix"}}]}},{"multi_match":{"query":"shawshank","type":"phrase","fields":["title","actors","query"]}}]}}}},"knn":{"field":"dense-vector-field","k":10,"num_candidates":100,"query_vector_builder":{"text_embedding":{"model_id":"cookie_model","model_text":"shawshank"}}},"size":20,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
+{"index":"imdb_movies"}
+{"aggs":{"type":{"terms":{"field":"type","size":10}}},"query":{"bool":{"filter":[],"must":{"bool":{"should":[{"bool":{"should":[{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"fuzziness":"AUTO:4,8"}},{"multi_match":{"query":"shawshank","fields":["title","actors","query"],"type":"bool_prefix"}}]}},{"multi_match":{"query":"shawshank","type":"phrase","fields":["title","actors","query"]}}]}}}},"knn":{"field":"dense-vector-field","k":10,"num_candidates":100,"query_vector_builder":{"text_embedding":{"model_id":"cookie_model","model_text":"shawshank"}}},"size":1,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
+"
+`;

--- a/packages/searchkit/src/___tests___/functional/__snapshots__/getQuery.test.ts.snap
+++ b/packages/searchkit/src/___tests___/functional/__snapshots__/getQuery.test.ts.snap
@@ -415,3 +415,209 @@ exports[`GetQuery Extension GetQuery Extension with query rules: ES Request 1`] 
 {"aggs":{"type":{"terms":{"field":"type","size":10}}},"query":{"bool":{"filter":[],"must":{"function_score":{"query":{"pinned":{"ids":["tt0111161"],"organic":{"multi_match":{"query":"shawshank","fields":["title","actors","query"]}}}},"functions":[]}}}},"size":1,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
 "
 `;
+
+exports[`GetQuery Extension do not apply organic query when set to false 2`] = `
+{
+  "results": [
+    {
+      "appliedRules": [],
+      "exhaustive": {
+        "facetsCount": true,
+        "nbHits": true,
+        "typo": true,
+      },
+      "exhaustiveFacetsCount": true,
+      "exhaustiveNbHits": true,
+      "exhaustiveTypo": true,
+      "facets": {
+        "actors": {
+          "Bob Gunton": 1,
+          "Morgan Freeman": 1,
+          "Tim Robbins": 1,
+          "William Sadler": 1,
+        },
+        "rated": {
+          "R": 1,
+        },
+        "type": {
+          "movie": 1,
+        },
+      },
+      "facets_stats": {},
+      "hits": [
+        {
+          "_highlightResult": {
+            "actors": [
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Tim Robbins",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Morgan Freeman",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Bob Gunton",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "William Sadler",
+              },
+            ],
+            "title": {
+              "fullyHighlighted": false,
+              "matchLevel": "full",
+              "matchedWords": [
+                "Shawshank",
+              ],
+              "value": "The <em>Shawshank</em> Redemption",
+            },
+          },
+          "actors": [
+            "Tim Robbins",
+            "Morgan Freeman",
+            "Bob Gunton",
+            "William Sadler",
+          ],
+          "objectID": "tt0111161",
+          "title": "The Shawshank Redemption",
+        },
+      ],
+      "hitsPerPage": 20,
+      "index": "imdb_movies",
+      "nbHits": 1,
+      "nbPages": 1,
+      "page": 0,
+      "params": "facetFilters=type%3Amovie&facets=*&highlightPostTag=%3C%2Fem%3E&highlightPreTag=%3Cem%3E&maxValuesPerFacet=10&page=0&query=test&tagFilters=",
+      "processingTimeMS": 2,
+      "query": "test",
+      "renderingContent": {
+        "facetOrdering": {
+          "facets": {
+            "order": [
+              "type",
+              "actors",
+              "rated",
+            ],
+          },
+          "values": {
+            "actors": {
+              "sortRemainingBy": "count",
+            },
+            "rated": {
+              "sortRemainingBy": "count",
+            },
+            "type": {
+              "sortRemainingBy": "count",
+            },
+          },
+        },
+      },
+    },
+    {
+      "appliedRules": [],
+      "exhaustive": {
+        "facetsCount": true,
+        "nbHits": true,
+        "typo": true,
+      },
+      "exhaustiveFacetsCount": true,
+      "exhaustiveNbHits": true,
+      "exhaustiveTypo": true,
+      "facets": {
+        "type": {
+          "movie": 1,
+        },
+      },
+      "facets_stats": {},
+      "hits": [
+        {
+          "_highlightResult": {
+            "actors": [
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Tim Robbins",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Morgan Freeman",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "Bob Gunton",
+              },
+              {
+                "matchLevel": "none",
+                "matchedWords": [],
+                "value": "William Sadler",
+              },
+            ],
+            "title": {
+              "fullyHighlighted": false,
+              "matchLevel": "full",
+              "matchedWords": [
+                "Shawshank",
+              ],
+              "value": "The <em>Shawshank</em> Redemption",
+            },
+          },
+          "actors": [
+            "Tim Robbins",
+            "Morgan Freeman",
+            "Bob Gunton",
+            "William Sadler",
+          ],
+          "objectID": "tt0111161",
+          "title": "The Shawshank Redemption",
+        },
+      ],
+      "hitsPerPage": 1,
+      "index": "imdb_movies",
+      "nbHits": 1,
+      "nbPages": 1,
+      "page": 0,
+      "params": "analytics=false&attributesToHighlight=&attributesToRetrieve=&attributesToSnippet=&clickAnalytics=false&facets=type&highlightPostTag=%3C%2Fem%3E&highlightPreTag=%3Cem%3E&hitsPerPage=1&maxValuesPerFacet=10&page=0&query=test&tagFilters=",
+      "processingTimeMS": 2,
+      "query": "test",
+      "renderingContent": {
+        "facetOrdering": {
+          "facets": {
+            "order": [
+              "type",
+              "actors",
+              "rated",
+            ],
+          },
+          "values": {
+            "actors": {
+              "sortRemainingBy": "count",
+            },
+            "rated": {
+              "sortRemainingBy": "count",
+            },
+            "type": {
+              "sortRemainingBy": "count",
+            },
+          },
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`GetQuery Extension do not apply organic query when set to false: ES Request 1`] = `
+"{"index":"imdb_movies"}
+{"aggs":{"type":{"terms":{"field":"type","size":10}},"actors":{"terms":{"field":"actors.keyword","size":10}},"rated":{"terms":{"field":"rated","size":10}}},"query":{"bool":{"filter":[{"bool":{"should":[{"term":{"type":"movie"}}]}}],"must":{"match_all":{}}}},"size":20,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
+{"index":"imdb_movies"}
+{"aggs":{"type":{"terms":{"field":"type","size":10}}},"query":{"bool":{"filter":[],"must":{"match_all":{}}}},"size":1,"from":0,"_source":{"includes":["title","actors","query"]},"highlight":{"pre_tags":["<em>"],"post_tags":["</em>"],"fields":{"title":{"number_of_fragments":0},"actors":{"number_of_fragments":0}}}}
+"
+`;

--- a/packages/searchkit/src/types.ts
+++ b/packages/searchkit/src/types.ts
@@ -4,8 +4,8 @@ import type {
   QueryDslQueryContainer as ElasticsearchQueryDslQuery,
   SearchResponseBody as ElasticsearchBaseResponseBody,
   SearchHit as ElasticsearchBaseHit,
-  AggregationsAggregation,
-  AggregationsAggregationContainer
+  AggregationsAggregationContainer,
+  KnnQuery as ElasticKnnSearchQuery
 } from '@elastic/elasticsearch/lib/api/types'
 
 type ElasticsearchHitDocument = Record<string, unknown>
@@ -15,6 +15,7 @@ type ElasticsearchResponseBody = ElasticsearchBaseResponseBody<ElasticsearchHitD
 
 type ElasticsearchQuery = ElasticsearchQueryDslQuery
 type ElasticsearchAggregation = AggregationsAggregationContainer
+type KnnSearchQuery = ElasticKnnSearchQuery
 
 export type MultipleQueriesQuery = AlgoliaMultipleQueriesQuery
 
@@ -210,17 +211,36 @@ export interface RequestOptions {
    * @param search_attributes The search attributes configured in the search settings
    * @param config The search settings
    * @returns An Elasticsearch query object or an array of Elasticsearch query objects
+   * @returns false if you want to skip the search query (useful for just KNN search)
    */
+
   getQuery?: (
     query: string,
     search_attributes: SearchAttribute[],
     config: SearchSettingsConfig
-  ) => ElasticsearchQuery | ElasticsearchQuery[]
+  ) => ElasticsearchQuery | ElasticsearchQuery[] | false
   /**
    * @description Allows you to add base filters to be applied to the search. This is useful for user / document level permissions
    * @returns An array of Elasticsearch query objects that will be wrapped in a bool filter query
    **/
   getBaseFilters?: () => ElasticsearchQuery[]
+
+  /**
+   * @description Allows you to specify the KNN query to be used for KNN search. Hits will be combined with the organic query. If you do not want to use the organic query, return false from getQuery.
+   * @param query The original query search terms
+   * @param search_attributes The search attributes configured in the search settings
+   * @param config The search settings
+   * @returns An Elasticsearch KNN Search Query
+   */
+  getKnnQuery?: (
+    query: string,
+    search_attributes: SearchAttribute[],
+    config: SearchSettingsConfig
+  ) => ElasticKnnSearchQuery
+
+  /**
+   * @description Hooks are escape hatches that allow you to modify the search requests to Elasticsearch and the responses back from Elasticsearch.
+   **/
   hooks?: {
     /**
      * @description Allows you to modify the search requests before they are sent to Elasticsearch
@@ -255,5 +275,6 @@ export type {
   ElasticsearchSearchRequest,
   ElasticsearchResponseBody,
   ElasticsearchHit,
-  ElasticsearchQuery
+  ElasticsearchQuery,
+  KnnSearchQuery
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,14 @@
     "@elastic/transport" "^8.3.1"
     tslib "^2.4.0"
 
+"@elastic/elasticsearch@^8.7.0":
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-8.7.0.tgz#eb0396f6899e0000109af55cffee514811e571ee"
+  integrity sha512-0u12N7gvSpv99XiiYE7OlOtVy4oFx7KNYd+/SSt0GqIcpj4X8bcILjpkQqK3HZcvkvwc8bFL9J11EMmUlg6FYw==
+  dependencies:
+    "@elastic/transport" "^8.3.1"
+    tslib "^2.4.0"
+
 "@elastic/transport@^8.2.0", "@elastic/transport@^8.3.1":
   version "8.3.1"
   resolved "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.1.tgz"


### PR DESCRIPTION
Much better support for KNN

```ts
 const results = await client.handleRequest(req.body, {
    getKnnQuery(query, search_attributes, config) {
      return {
        field: 'dense-vector-field',
        k: 10,
        num_candidates: 100,
        // supported in latest version of Elasticsearch
        query_vector_builder: { 
          text_embedding: {
            model_id: 'cookie_model',
            model_text: query
          }
        }
      }
    }
  });
```