### PR TITLE
Improve nextjs tutorial

### DIFF
--- a/apps/web/pages/autocomplete.jsx
+++ b/apps/web/pages/autocomplete.jsx
@@ -7,6 +7,7 @@ import React, { createElement, Fragment, useEffect, useRef, useState } from 'rea
 import { render } from 'react-dom';
 import client from "@searchkit/instantsearch-client";
 import { InstantSearch, usePagination, useSearchBox, Hits } from 'react-instantsearch-hooks-web';
+import Head from 'next/head'
 
 function Autocomplete(props) {
   const containerRef = useRef(null);
@@ -170,6 +171,9 @@ function createCategoriesPlugin({
 export default function AutocompletePage() {
   return (
     <div className="bg-gray-100 h-screen p-4">
+        <Head>
+            <title>Autocomplete demo</title>
+        </Head>
       <InstantSearch
         searchClient={searchClient}
         indexName="imdb_movies"

--- a/apps/web/pages/camping-sites-demo.jsx
+++ b/apps/web/pages/camping-sites-demo.jsx
@@ -1,6 +1,6 @@
 import { InstantSearch, SearchBox, Hits, Highlight, createConnector, DynamicWidgets, RefinementList, ToggleRefinement, Panel, Pagination, Stats, connectSearchBox, NumericMenu, RangeInput, CurrentRefinements, QueryRuleCustomData, Snippet, SortBy, Configure, HierarchicalMenu } from 'react-instantsearch-dom';
 import Client from '@searchkit/instantsearch-client'
-import Script from 'next/script'
+import Head from 'next/head'
 import Searchkit from "searchkit"
 
 import {
@@ -98,7 +98,9 @@ const endpoint = 'https://maps.googleapis.com/maps/api/js?v=weekly';
 export default function Web() {
     return (
       <div className="ais-InstantSearch bg-gray-100 h-screen p-4">
-        <Script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c98b302ea3bb4a33a012a7ef0ab3e240"}' />
+        <Head>
+            <title>Camping sites Demo</title>
+        </Head>
   
       <InstantSearch
         indexName="search-camping-sites"

--- a/apps/web/pages/demo-ecommerce.tsx
+++ b/apps/web/pages/demo-ecommerce.tsx
@@ -6,6 +6,7 @@ import Client from '@searchkit/instantsearch-client'
 import { GetServerSideProps } from 'next';
 import { createInstantSearchRouterNext } from 'react-instantsearch-hooks-router-nextjs';
 import singletonRouter from 'next/router';
+import Head from 'next/head'
 
 const hitView = (props: any) => {
   return (
@@ -42,6 +43,9 @@ export default function Web({ serverState, url, serverUrl }: WebProps) {
       <InstantSearchSSRProvider {...serverState}>
 
         <div className="ais-InstantSearch bg-gray-100 h-screen p-4">
+          <Head>
+            <title>Searchkit Ecommerce Demo</title>
+          </Head>
 
         <InstantSearch
         indexName="search-ecommerce"

--- a/apps/web/pages/demo-ecommerce.tsx
+++ b/apps/web/pages/demo-ecommerce.tsx
@@ -32,11 +32,11 @@ type WebProps = {
   serverUrl?: string;
 };
 
-const searchClient = Client({
-  url: serverUrl + '/api/product-search',
-});
-
 export default function Web({ serverState, url, serverUrl }: WebProps) {
+
+    const searchClient = Client({
+      url: serverUrl + '/api/product-search',
+    });
 
     return (
       <InstantSearchSSRProvider {...serverState}>

--- a/apps/web/pages/demo.tsx
+++ b/apps/web/pages/demo.tsx
@@ -1,6 +1,7 @@
 import { InstantSearch, SearchBox, Hits, Highlight, DynamicWidgets, RefinementList, Pagination, Stats, RangeInput, CurrentRefinements, Snippet, SortBy, InstantSearchServerState, InstantSearchSSRProvider, useHits, HitsProps } from 'react-instantsearch-hooks-web';
 import { getServerState } from 'react-instantsearch-hooks-server';
 import { renderToString } from 'react-dom/server';
+import Head from "next/head"
 
 import Client from '@searchkit/instantsearch-client'
 import Searchkit from "searchkit"
@@ -8,19 +9,6 @@ import { config } from "./api/config"
 import { GetServerSideProps } from 'next';
 import { createInstantSearchRouterNext } from 'react-instantsearch-hooks-router-nextjs';
 import singletonRouter from 'next/router';
-
-const hitView = (props: any) => {
-  return (
-    <div className="bg-white rounded-lg overflow-hidden shadow">
-      <img src={props.hit.poster} alt="movie cover" className="w-full h-64 object-cover"/>
-    <div className="p-4">
-        <h3 className="text-lg font-semibold"><Highlight hit={props.hit} attribute="title" /></h3>
-        <p className="text-gray-600">      <Snippet hit={props.hit} attribute="plot" />
-</p>
-    </div>
-    </div>
-  )
-}
 
 const Panel = ({ header, children }: { header: string, children: any }) => (
   <div className="mb-4">
@@ -63,7 +51,9 @@ export default function Web({ serverState, url }: WebProps) {
       <InstantSearchSSRProvider {...serverState}>
 
       <div className="ais-InstantSearch bg-gray-100 h-screen p-4">
-  
+        <Head>
+          <title>Searchkit Demo</title>
+        </Head>
       <InstantSearch
         indexName="imdb_movies"
         searchClient={searchClient}

--- a/apps/web/pages/docs/getting-started/with-react.mdx
+++ b/apps/web/pages/docs/getting-started/with-react.mdx
@@ -12,7 +12,7 @@ import Setup from "./setup.mdx"
 This guide will show you how to get started with Searchkit and React Instantsearch components.
 
 <Callout type="info">
-  If you use Next.js, checkout the <a href="/tutorials/with-nextjs">Next.js guide</a> for a simpler setup.
+  If you use Next.js, checkout the <a href="/docs/tutorials/with-nextjs">Next.js guide</a> for a simpler setup.
 </Callout>
 
 ## Download an Example Project

--- a/apps/web/pages/docs/overview.mdx
+++ b/apps/web/pages/docs/overview.mdx
@@ -34,7 +34,7 @@ Searchkit simplifies this process by providing a layer of abstraction on top of 
 * [Searchkit Node API Video Tutorial](https://www.youtube.com/watch?v=8ztvn1-VZ_U)
 
 ## Tutorials
-* [Searchkit with Next.js](https://www.searchkit.co/tutorials/with-nextjs)
+* [Searchkit with Next.js](https://www.searchkit.co/docs/tutorials/with-nextjs)
 * [Searchkit with Availability Search](https://www.searchkit.co/tutorials/build-availability-search-ui)
 
 ## Demos

--- a/apps/web/pages/docs/tutorials/with-nextjs.mdx
+++ b/apps/web/pages/docs/tutorials/with-nextjs.mdx
@@ -5,6 +5,8 @@ keywords: ["nextjs", "searchkit", "tutorial", "walkthrough", "elasticsearch", "r
 ---
 
 import { Tabs, Tab } from '../../../components/Tabs'
+import { Callout } from 'nextra/components'
+
 
 ## Get Started
 
@@ -47,6 +49,10 @@ style={{
    ></iframe>
 
 ## Create a Next.js app
+
+<Callout type="info" emoji="ℹ️">
+  This tutorial will use Next.js new App Router. If you're using pages, keep this in mind when following along.
+</Callout>
 
 First, we need to create a Next.js app. We can do this by running the following command:
 
@@ -91,10 +97,11 @@ Next we need to install the dependencies for this project:
 
 ## Setup the Node API
 
-create a new file in the `pages/api` directory called `search.js` and add the following code:
+create a new file in the `app/api/search` directory called `route.ts` and add the following code:
 
-```js
-import Client from "@searchkit/api";
+```ts filename="app/api/search/route.ts"
+import Client from "@searchkit/api";]
+import { NextRequest, NextResponse } from 'next/server'
 
 const apiConfig = {
   connection: {
@@ -119,15 +126,17 @@ const apiConfig = {
 
 const apiClient = Client(apiConfig);
 
-export default async function handler(req, res) {
-  const results = await apiClient.handleRequest(req.body);
-  res.send(results);
+export async function POST(req: NextRequest, res: NextResponse) {
+  const data = await req.json()
+
+  const results = await apiClient.handleRequest(data)
+  return NextResponse.json(results)
 }
 ```
 
 Replace the _host_ and _apiKey_ with your Elasticsearch host and API key. The apiKey is optional, but recommended for production environments. You can find more information about the API key [here](https://www.elastic.co/guide/en/kibana/master/api-keys.html).
 
-This will setup a new [nextjs api route](https://nextjs.org/docs/api-routes/introduction) under the `/api/search` path. This route will handle the search requests and use instantsearch Elasticsearch Adapter to handle the requests. The response is then returned back to the client.
+This will setup a new [nextjs route handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) under the `/api/search` path. This route will handle the search requests and use instantsearch Elasticsearch Adapter to handle the requests. The response is then returned back to the client.
 
 For more information on API configuration, see the [API Configuration](/reference/api) docs.
 
@@ -135,9 +144,9 @@ For more information on API configuration, see the [API Configuration](/referenc
 
 Now that we have the API setup, we can start building the frontend. We will use [react-instantsearch-hooks-web](https://www.algolia.com/doc/api-reference/widgets/react-hooks/) to build the search experience.
 
-First, we need to create a new file in the `pages` directory called `search.js` and add the following code:
+First, we need to create a new file in the `app` directory called `page.tsx` and add the following code:
 
-```js
+```js filename="app/page.tsx"
 import { InstantSearch, SearchBox, Hits } from "react-instantsearch-hooks-web";
 import createClient from "@searchkit/instantsearch-client";
 
@@ -185,7 +194,7 @@ Now that we have the search experience setup, we can add the search functionalit
 
 ### Adjusting the search fields
 
-we can adjust the search fields by updating the `search_attributes` in the `apiConfig` object in the `pages/api/search.js` file.
+we can adjust the search fields by updating the `search_attributes` in the `apiConfig` object in the `app/api/search/route.ts` file.
 
 ```js
   search_attributes: ["title^3", "actors", "plot"],
@@ -195,7 +204,7 @@ Above we have boosted title by 3 times. This means that the title will have a hi
 
 ### Overriding the default Elasticsearch query
 
-We can optionally override the default search query by implementing the `getQuery` function in the `handleRequest` method called in `pages/api/search.js` file.
+We can optionally override the default search query by implementing the `getQuery` function in the `handleRequest` method called in `app/api/search/route.ts` file.
 
 this function will receive the query and the function will return the Elasticsearch query that will be used to search the index.
 
@@ -220,7 +229,7 @@ We can add a custom hit component to display the results. We can create a new fi
 
 Below we are using the `Highlight` component from `react-instantsearch-hooks-web` to highlight the search term in the title and actors fields.
 
-```js filename="index.js"
+```js filename="components/Hit.tsx"
 import { Highlight } from "react-instantsearch-hooks-web";
 
 const hitView = (props) => {
@@ -239,11 +248,11 @@ const hitView = (props) => {
 
 We need to pass the `attribute` prop to the `highlight_attributes` config to tell which fields to bring highlight options for.
 
-```js filename="pages/api/search.js"
+```js filename="app/page.tsx"
   highlight_attributes: ["title", "actors"],
 ```
 
-then we can import the `Hit` component in the `pages/search.js` file and pass it to the `Hits` component.
+then we can import the `Hit` component in the `app/page.tsx` file and pass it to the `Hits` component.
 
 ```js
 import Hit from "../components/Hit";
@@ -258,15 +267,13 @@ export default function Search() {
 }
 ```
 
-IMAGE3
-
 ## Facets
 
 ### Adding a Refinement List Facet
 
-Start by updating the `apiConfig` object in the `pages/api/search.js` file to add the `type` facet.
+Start by updating the `apiConfig` object in the `app/api/search/route.ts` file to add the `type` facet.
 
-```js filename="pages/api/search.js"
+```js filename="app/api/search/route.ts"
   facet_attributes: ["type"],
 ```
 
@@ -299,8 +306,6 @@ export default function Search() {
 }
 ```
 
-IMAGE4
-
 #### Make it searchable
 
 By default, the `RefinementList` component will show all the values for the facet. We can make it searchable by adding the `searchable` prop.
@@ -311,7 +316,7 @@ By default, the `RefinementList` component will show all the values for the face
 
 ### Adding a Numeric Range based Facet
 
-Start by updating the `apiConfig` object in the `pages/api/search.js` file to add the `imdbrating` facet.
+Start by updating the `apiConfig` object in the `app/page.tsx` file to add the `imdbrating` facet.
 This requires the `imdbrating` field to be a numeric type field like a `float` in the Elasticsearch index.
 
 ```js
@@ -321,7 +326,7 @@ facet_attributes: [
 ],
 ```
 
-Then we can add the `RangeInput` component to the `pages/search.js` file.
+Then we can add the `RangeInput` component to the `app/page.tsx` file.
 
 ```js
 import {

--- a/apps/web/pages/geo-search-demo.jsx
+++ b/apps/web/pages/geo-search-demo.jsx
@@ -1,7 +1,7 @@
 import { InstantSearch, Hits, RefinementList } from 'react-instantsearch-dom';
 import Client from '@searchkit/instantsearch-client'
-import Script from 'next/script'
 import Searchkit from "searchkit"
+import Head from "next/head"
 
 import {
   GoogleMapsLoader,
@@ -40,8 +40,9 @@ const hitView = (props) => {
 export default function Web() {
     return (
       <div className="ais-InstantSearch bg-gray-100 h-screen p-4">
-        <Script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c98b302ea3bb4a33a012a7ef0ab3e240"}' />
-  
+        <Head>
+            <title>Geo Search demo</title>
+        </Head>
       <InstantSearch
         indexName="us_parks"
         searchClient={searchClient}

--- a/examples/with-ui-nextjs-react/app/api/search/route.ts
+++ b/examples/with-ui-nextjs-react/app/api/search/route.ts
@@ -1,5 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
 import API, { MatchFilter } from '@searchkit/api'
-import { NextApiRequest, NextApiResponse } from 'next'
 
 const apiClient = API(
   {
@@ -158,7 +158,9 @@ const apiClient = API(
   { debug: true }
 )
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const results = await apiClient.handleRequest(req.body)
-  res.send(results)
+export async function POST(req: NextRequest, res: NextResponse) {
+  const data = await req.json()
+
+  const results = await apiClient.handleRequest(data)
+  return NextResponse.json(results)
 }

--- a/examples/with-ui-nextjs-react/app/layout.tsx
+++ b/examples/with-ui-nextjs-react/app/layout.tsx
@@ -1,0 +1,14 @@
+import "instantsearch.css/themes/satellite-min.css"
+import '@/styles/globals.css'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/examples/with-ui-nextjs-react/app/page.tsx
+++ b/examples/with-ui-nextjs-react/app/page.tsx
@@ -1,3 +1,4 @@
+"use client"
 import {
   InstantSearch,
   SearchBox,
@@ -63,7 +64,7 @@ const QueryRulesBanner = () => {
 export default function Web() {
   return (
     <div className="">
-      <InstantSearch indexName="products" searchClient={searchClient}>
+      <InstantSearch indexName="products" searchClient={searchClient} routing>
         <Configure hitsPerPage={15} />
         <div className="container">
           <div className="search-panel">

--- a/examples/with-ui-nextjs-react/pages/_app.tsx
+++ b/examples/with-ui-nextjs-react/pages/_app.tsx
@@ -1,7 +1,0 @@
-import '@/styles/globals.css'
-import type { AppProps } from 'next/app'
-import "instantsearch.css/themes/satellite-min.css"
-
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
-}


### PR DESCRIPTION
this updates the tutorial to show examples using the app router instead of the "legacy" pages router. 