### PR TITLE
fix searchkit with Availability Search tutorial url

### DIFF
--- a/apps/web/pages/docs/overview.mdx
+++ b/apps/web/pages/docs/overview.mdx
@@ -35,7 +35,7 @@ Searchkit simplifies this process by providing a layer of abstraction on top of 
 
 ## Tutorials
 * [Searchkit with Next.js](https://www.searchkit.co/docs/tutorials/with-nextjs)
-* [Searchkit with Availability Search](https://www.searchkit.co/tutorials/build-availability-search-ui)
+* [Searchkit with Availability Search](https://www.searchkit.co/docs/tutorials/build-availability-search-ui)
 
 ## Demos
 * [Searchkit with Next.js](https://www.searchkit.co/demo)


### PR DESCRIPTION
missing `docs` in the original mdx.