### PR TITLE
add support to floating point numeric filters

### DIFF
--- a/.changeset/bright-points-explode.md
+++ b/.changeset/bright-points-explode.md
@@ -1,0 +1,5 @@
+---
+'searchkit': patch
+---
+
+Support for decimal numeric filters

--- a/packages/searchkit/src/___tests___/filters.test.ts
+++ b/packages/searchkit/src/___tests___/filters.test.ts
@@ -114,6 +114,49 @@ describe('filter functions', () => {
     `)
   })
 
+  it('transforms floating numeric filters', () => {
+    const numericFilter = `price >= -100.51`
+
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config))
+      .toMatchInlineSnapshot(`
+    [
+      {
+        "range": {
+          "price": {
+            "gte": "-100.51",
+          },
+        },
+      },
+    ]
+  `)
+  })
+
+  it('transforms floating optional integer and optional fraction', () => {
+    const numericFilter = `price:-.51 TO 1.`
+    expect(transformNumericFilters(getNumericFilterRequest(numericFilter), config))
+      .toMatchInlineSnapshot(`
+    [
+      {
+        "range": {
+          "price": {
+            "gte": "-.51",
+            "lte": "1.",
+          },
+        },
+      },
+    ]
+  `)
+  })
+
+  it('transforms on malformed numeric fraction', () => {
+    const numericFilter = `price >= .`
+    expect(() =>
+      transformNumericFilters(getNumericFilterRequest(numericFilter), config)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Numeric filter "price >= ." could not be parsed. It should either be in the format "attributeName operator operand" or "attributeName: lowerBound TO upperBound""`
+    )
+  })
+
   it('throws on malformed numeric filters', () => {
     const numericFilter = `price xxx 100`
 

--- a/packages/searchkit/src/filters.ts
+++ b/packages/searchkit/src/filters.ts
@@ -23,7 +23,7 @@ export const transformNumericFilters = (
   return numericFilters.reduce((sum, filter: string) => {
     let match, field, operator, value, maxValue = ''
     let groups = filter.match(
-      /([\w\.\_\-]+)\s*(\=|\!\=|\>|\>\=|\<|\<\=)\s*(-?\d+)/
+      /([\w\.\_\-]+)\s*(\=|\!\=|\>|\>\=|\<|\<\=)\s*(-?(?:\d+(?:\.\d*)?|\.\d+))/
     )
 
     if (groups) {
@@ -32,7 +32,7 @@ export const transformNumericFilters = (
     else {
       // Alternative syntax: 'attribute:lower_value TO higher_value'
       groups = filter.match(
-        /([\w\.\_\-]+):\s*(-?\d+)\s*([Tt][Oo])\s*(-?\d+)/
+        /([\w\.\_\-]+):\s*(-?(?:\d+(?:\.\d*)?|\.\d+))\s*([Tt][Oo])\s*(-?(?:\d+(?:\.\d*)?|\.\d+))/
       )
 
       if (!groups) {


### PR DESCRIPTION
Adds support to floating point numeric filters such to be used in instantsearch queries such as:

```
{
   numericFilters: [
       "total_amount >= 7.13",
       "total_amount<=7.29"
   ]
}
```

The approach used was to improve the digit selector `\d+` in the regex to the following:`(?:\d+(?:\.\d*)?|\.\d+)`, allowing to match number such as `100.2`, 100.` and `1.`. This ensures support for:

- Numbers with a decimal part (e.g., 100.2)
- Whole numbers ending with a decimal (e.g., 100.)
- Numbers with a leading decimal point and a fractional part (e.g., .1)

The updated pattern incorporates non-capturing groups, indicated by the usage of ?:. This approach ensures that this change integrates with the existing logic without requiring further alterations.