### PR TITLE
Change content-type from json to x-ndjson (sent by searchkit to the search engine API)

### DIFF
--- a/packages/searchkit/src/Transporter.ts
+++ b/packages/searchkit/src/Transporter.ts
@@ -42,7 +42,7 @@ export class ESTransporter implements Transporter {
     return fetch(`${host}/_msearch`, {
       headers: {
         ...(this.config.apiKey ? { authorization: `ApiKey ${this.config.apiKey}` } : {}),
-        'content-type': 'application/json',
+        'content-type': 'application/x-ndjson',
         ...(this.config.headers || {}),
         ...(this.config.auth
           ? {

--- a/packages/searchkit/src/___tests___/functional/Transporter.browser.test.ts
+++ b/packages/searchkit/src/___tests___/functional/Transporter.browser.test.ts
@@ -49,7 +49,7 @@ describe('Transporter - browser', () => {
     expect((global.fetch as jest.Mock).mock.calls[0][1].headers).toMatchInlineSnapshot(`
       {
         "Authorization": "Basic ZWxhc3RpYzpjaGFuZ2VtZQ==",
-        "content-type": "application/json",
+        "content-type": "application/x-ndjson",
       }
     `)
   })

--- a/packages/searchkit/src/___tests___/functional/Transporter.test.ts
+++ b/packages/searchkit/src/___tests___/functional/Transporter.test.ts
@@ -75,7 +75,7 @@ describe('Transporter', () => {
       {
         "X-Custom-Header": "custom header value",
         "authorization": "ApiKey apiKey",
-        "content-type": "application/json",
+        "content-type": "application/x-ndjson",
       }
     `)
   })
@@ -116,7 +116,7 @@ describe('Transporter', () => {
     expect((global.fetch as jest.Mock).mock.calls[0][1].headers).toMatchInlineSnapshot(`
       {
         "Authorization": "Basic ZWxhc3RpYzpjaGFuZ2VtZQ==",
-        "content-type": "application/json",
+        "content-type": "application/x-ndjson",
       }
     `)
   })
@@ -186,6 +186,8 @@ describe('Transporter', () => {
       nonDynamicFacetRequest as AlgoliaMultipleQueriesQuery[]
     )
 
-    expect((global.fetch as jest.Mock).mock.calls[0][1].credentials).toMatchInlineSnapshot(`"include"`)
+    expect((global.fetch as jest.Mock).mock.calls[0][1].credentials).toMatchInlineSnapshot(
+      `"include"`
+    )
   })
 })


### PR DESCRIPTION
Searchkit was sending "application/json" to the search engine API, this is technically incorrect, since the body of the request is a list of jsons concatenated by newline. This breaks the parsing of the request body on some (proxy) servers, for example Ruby on Rails, since when it tries to parse a json, if finds it is broken.

This fixes #1360.