### PR TITLE
Switch to json content type

### DIFF
--- a/.changeset/cold-grapes-change.md
+++ b/.changeset/cold-grapes-change.md
@@ -1,0 +1,5 @@
+---
+'searchkit': patch
+---
+
+switch back to content-type application/json

--- a/apps/web/pages/docs/proxy-elasticsearch/with-your-own-server.mdx
+++ b/apps/web/pages/docs/proxy-elasticsearch/with-your-own-server.mdx
@@ -13,3 +13,9 @@ Continue to generate Elasticsearch queries from the browser with Searchkit but p
 ## Change the request to my own API
 
 Implement your own API route on your application server by creating a POST `/_msearch` API and specify your application server in the `host` property or building a [custom transporter](/docs/guides/setup-elasticsearch#custom-transport). Searchkit will make requests to the proxy which will then relay the request to Elasticsearch with read only security credentials and extra filtering restrictions (if needed).  
+
+## Customise the network request
+
+You can customise the network request by creating a custom transporter. This is useful if you want to add additional headers or modify the request before it is sent to Elasticsearch. 
+
+see [Custom Transporter](/docs/api-documentation/searchkit#custom-transporter)

--- a/packages/searchkit/src/Transporter.ts
+++ b/packages/searchkit/src/Transporter.ts
@@ -42,7 +42,7 @@ export class ESTransporter implements Transporter {
     return fetch(`${host}/_msearch`, {
       headers: {
         ...(this.config.apiKey ? { authorization: `ApiKey ${this.config.apiKey}` } : {}),
-        'content-type': 'application/x-ndjson',
+        'content-type': 'application/json',
         ...(this.config.headers || {}),
         ...(this.config.auth
           ? {

--- a/packages/searchkit/src/___tests___/functional/Transporter.browser.test.ts
+++ b/packages/searchkit/src/___tests___/functional/Transporter.browser.test.ts
@@ -49,7 +49,7 @@ describe('Transporter - browser', () => {
     expect((global.fetch as jest.Mock).mock.calls[0][1].headers).toMatchInlineSnapshot(`
       {
         "Authorization": "Basic ZWxhc3RpYzpjaGFuZ2VtZQ==",
-        "content-type": "application/x-ndjson",
+        "content-type": "application/json",
       }
     `)
   })

--- a/packages/searchkit/src/___tests___/functional/Transporter.test.ts
+++ b/packages/searchkit/src/___tests___/functional/Transporter.test.ts
@@ -75,7 +75,7 @@ describe('Transporter', () => {
       {
         "X-Custom-Header": "custom header value",
         "authorization": "ApiKey apiKey",
-        "content-type": "application/x-ndjson",
+        "content-type": "application/json",
       }
     `)
   })
@@ -116,7 +116,7 @@ describe('Transporter', () => {
     expect((global.fetch as jest.Mock).mock.calls[0][1].headers).toMatchInlineSnapshot(`
       {
         "Authorization": "Basic ZWxhc3RpYzpjaGFuZ2VtZQ==",
-        "content-type": "application/x-ndjson",
+        "content-type": "application/json",
       }
     `)
   })


### PR DESCRIPTION
Impacting servers which dont honour the nd-json type. Switching back to this and adding documentation to note you can override the content type via `CustomTransporter` or providing the content-type via headers option.