### PR TITLE
Complete support colons in facet values

### DIFF
--- a/packages/searchkit/src/filters.ts
+++ b/packages/searchkit/src/filters.ts
@@ -190,7 +190,7 @@ export const transformFacetFilters = (
         {
           bool: {
             should: filter.reduce((sum, filter) => {
-              const [facet, value] = filter.split(':')
+              const [facet, value] = filter.split(/:(.*)/)
               const facetFilterConfig = facetFilterMap[facet]
               if (!facetFilterConfig)
                 throw new Error(
@@ -246,7 +246,7 @@ export const transformFacetFilters = (
         }
       ]
     } else if (typeof filter === 'string') {
-      const [facet, value] = filter.split(':')
+      const [facet, value] = filter.split(/:(.*)/)
 
       const facetFilterConfig = facetFilterMap[facet]
       if (!facetFilterConfig)


### PR DESCRIPTION
I'm sorry but somehow I missed one line in the code in #1395 where it is also necessary to replace the parameter for `split`.