### PR TITLE
Allow fuzziness to be configured

### DIFF
--- a/apps/web/pages/docs/api-documentation/searchkit.mdx
+++ b/apps/web/pages/docs/api-documentation/searchkit.mdx
@@ -219,6 +219,7 @@ Attributes that are used to configure the search experience.
 - `snippet_attributes` - Attributes that are used for highlighting search results for long fields.
 - `sorting` - Attributes that are used to create sorting options. Sorting can be a single sorting field or multiple.
 - `query_rules` - Rules that affect search relevance. See [Query Rules](/docs//query-rules) for more information.
+- `fuzziness` - The [fuzziness](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) that should be used for text queries. Defaults to `AUTO:4,8`.
 - `geo_attribute` - Attribute that is used for geo based searches.
 - `runtime_mappings` - Runtime mappings that are used to transform fields in the search results. See [Runtime Mappings](/docs/guides/runtime-mappings) for more information. Once used, you are able to use the transformed field in the `search_attributes`, `result_attributes`, `facet_attributes` and `filter_attributes` configuration.
 

--- a/packages/searchkit/src/transformRequest.ts
+++ b/packages/searchkit/src/transformRequest.ts
@@ -154,7 +154,7 @@ function queryRulesWrapper(organicQuery: any, queryRuleActions: QueryRuleActions
   return organicQuery
 }
 
-export function RelevanceQueryMatch(query: string, search_attributes: SearchAttribute[]) {
+export function RelevanceQueryMatch(query: string, search_attributes: SearchAttribute[], fuzziness: string = 'AUTO:4,8') {
   const getFieldsMap = (boostMultiplier: number) => {
     return search_attributes.map((attribute) => {
       return typeof attribute === 'string'
@@ -173,7 +173,7 @@ export function RelevanceQueryMatch(query: string, search_attributes: SearchAttr
                 multi_match: {
                   query: query,
                   fields: getFieldsMap(1),
-                  fuzziness: 'AUTO:4,8'
+                  fuzziness: fuzziness
                 }
               },
               {
@@ -207,6 +207,7 @@ const getQuery = (
   const query = queryRuleActions.query
 
   const searchAttributes = config.search_attributes
+  const fuzziness = config.fuzziness ?? 'AUTO:4,8'
 
   const filters = [
     ...transformFacetFilters(request, config),
@@ -221,7 +222,7 @@ const getQuery = (
     typeof query === 'string' && query !== ''
       ? requestOptions?.getQuery
         ? requestOptions.getQuery(query, searchAttributes, config)
-        : RelevanceQueryMatch(query, searchAttributes)
+        : RelevanceQueryMatch(query, searchAttributes, fuzziness)
       : {
           match_all: {}
         }

--- a/packages/searchkit/src/types.ts
+++ b/packages/searchkit/src/types.ts
@@ -153,6 +153,10 @@ export interface SearchSettingsConfig {
    */
   sorting?: Record<string, SortingOption | SortingOption[]>
   /**
+   * @description The fuzziness of the text search query. Defaults to AUTO:4,8
+   */
+  fuzziness?: string
+  /**
    * @description The attribute that will be used for geo search. This is required if you want to use geo search. Must be am Elasticsearch geo_point type field.
    */
   geo_attribute?: string


### PR DESCRIPTION
We have a few sites where we would like to tweak the fuzziness slightly. This is currently not possible as it is hardcoded. By adding this into the config, we can tweak this.

I'm not sure if this would be the best place to actually put it but I couldn't find anything that would be better.