### PR TITLE
Fix link in documentation

### DIFF
--- a/apps/web/pages/docs/api-documentation/searchkit.mdx
+++ b/apps/web/pages/docs/api-documentation/searchkit.mdx
@@ -279,7 +279,7 @@ Below is an example of a `RefinementList` Instantsearch React component that use
 <RefinementList attribute="actors" searchable={true} limit={10} />
 ```
 
-See [facets guide](/docs/guides/facets) for more information.
+See [facets guide](/docs/guides/facets/string-based-facets) for more information.
 
 ##### Custom Aggregations & Filter Queries
 


### PR DESCRIPTION
The path `/docs/guides/facets/` doesn't exist (yet) so it's better to link a sub-page than to have a link leading to a kind of 404 page.