### PR TITLE
Always call getQuery when getQuery is set regardless of the query string

### DIFF
--- a/packages/searchkit/src/transformRequest.ts
+++ b/packages/searchkit/src/transformRequest.ts
@@ -219,13 +219,13 @@ const getQuery = (
   ]
 
   let organicQuery =
-    typeof query === 'string' && query !== ''
-      ? requestOptions?.getQuery
-        ? requestOptions.getQuery(query, searchAttributes, config)
-        : RelevanceQueryMatch(query, searchAttributes, fuzziness)
-      : {
-          match_all: {}
-        }
+    requestOptions?.getQuery
+      ? requestOptions.getQuery(query, searchAttributes, config)
+      : typeof query === 'string' && query !== ''
+        ? RelevanceQueryMatch(query, searchAttributes, fuzziness)
+        : {
+            match_all: {}
+          }
 
   const hasKnn = typeof requestOptions?.getKnnQuery === 'function'
   const hasNoQuery = requestOptions?.getQuery?.(query, searchAttributes, config) === false


### PR DESCRIPTION
We ran into a case where we wanted to have a custom query but not care about the query string. Specifically, we wanted to have a complete product listing merely sorted by a `function_score` with a `script_score`, which needs to go into the query.

After some debugging we found out that this did not work until we made the query string non-null, even though that string doesn't actually get used anywhere within our query.

Turning around the functionality of these ternary operators allows us to use a custom query without requiring the query string to be a non-empty string.