### PR TITLE
Export relevance query so it can be re-used outside of the package

### DIFF
--- a/packages/searchkit/src/index.ts
+++ b/packages/searchkit/src/index.ts
@@ -6,6 +6,8 @@ import { ESTransporter } from './Transporter'
 import { getQueryRulesActionsFromRequest, QueryRuleActions } from './queryRules'
 import { createElasticsearchQueryFromRequest } from './utils'
 import { getIndexName } from './sorting'
+
+export { RelevanceQueryMatch } from './transformRequest'
 export * from './types'
 export * from './Transporter'
 export * from './filterUtils'


### PR DESCRIPTION
We would like to re-use this query function in some cases so we can have certain custom queries without having to deviate from the relevance query used by default (or having to copy paste this function).