### PR TITLE
Pass request along to query

### DIFF
--- a/packages/searchkit/src/transformRequest.ts
+++ b/packages/searchkit/src/transformRequest.ts
@@ -221,14 +221,14 @@ const getQuery = (
   let organicQuery =
     typeof query === 'string' && query !== ''
       ? requestOptions?.getQuery
-        ? requestOptions.getQuery(query, searchAttributes, config)
+        ? requestOptions.getQuery(query, searchAttributes, {...config, request: request})
         : RelevanceQueryMatch(query, searchAttributes, fuzziness)
       : {
           match_all: {}
         }
 
   const hasKnn = typeof requestOptions?.getKnnQuery === 'function'
-  const hasNoQuery = requestOptions?.getQuery?.(query, searchAttributes, config) === false
+  const hasNoQuery = requestOptions?.getQuery?.(query, searchAttributes, {...config, request: request}) === false
 
   if (hasNoQuery || (hasKnn && query === '')) {
     organicQuery = {
@@ -250,7 +250,7 @@ const getQuery = (
   if (hasKnn && query !== '') {
     knnQueryDsl = {
       filter: filters,
-      ...(requestOptions?.getKnnQuery?.(query, searchAttributes, config) || {})
+      ...(requestOptions?.getKnnQuery?.(query, searchAttributes, {...config, request: request}) || {})
     } as KnnSearchQuery
   }
 


### PR DESCRIPTION
With the introduction of neural search you'd want to make sure the query only gets added to indexes that contain that neural field.

This change adds the request to the query config, this way you could access `config.request.indexName` in order to verify the request is done to the correct index before adding the neural line. This would look like:

```js
function getInstantSearchClientConfig() {
    return {
        getQuery: function (query, search_attributes, config) {
            if (config.request.indexName === 'products') {
                return {
                    'neural': {
                        'content_embedding': {
                            'query_text': query,
                            'model_id': '...',
                            'min_score': 0.9,
                        }
                    }
                }
            }
            // Other indexes searched, like categories, search suggestions, pages will get standard search
            return parent.getQuery(query, search_attributes, config)
        }
    }
}
```